### PR TITLE
Minimize rerender

### DIFF
--- a/client/src/screens/Overview/EHROverviewScreen.js
+++ b/client/src/screens/Overview/EHROverviewScreen.js
@@ -24,7 +24,7 @@ export function EHROverviewScreen(props) {
 
 
   // FOR TESTING, CHANGE THIS TO "doctor" or "patient", to access the 2 views
-  const placeholderRole = "doctor";
+  const placeholderRole = "patient";
 
   const [state, setState] = useState({
     doctorRole: false,
@@ -39,6 +39,7 @@ export function EHROverviewScreen(props) {
     inputEmail: "",
     modalVisible: false,
     showWarning: false,
+    regionSnapshot: []
   }) 
 
 
@@ -47,7 +48,6 @@ export function EHROverviewScreen(props) {
 
 
 
-  const [regions,setRegions] = useState([]);
 
   const [patientInfo,setPatientInfo] = useState(PlaceholderValues.patient);
 
@@ -109,7 +109,8 @@ export function EHROverviewScreen(props) {
                 permittedRegions:patientPermittedRegions,
                 journals:patientJournals
               },
-              regions:regionIndexes
+              regions:[...regionIndexes],
+              regionSnapshot: [...regionIndexes],
             }))
 
             
@@ -132,12 +133,6 @@ export function EHROverviewScreen(props) {
               permittedRegions:patientPermittedRegions,
               journals:patientJournals
             }))
-            setRegions((prevState) => {
-              prevState = [];
-              allRegions.forEach((reg) => prevState.push({name:reg,enabled:false}))
-              patientPermittedRegions.forEach((reg) => prevState.find(r => r.name === reg).enabled = true)
-              return[...prevState]
-            })
           }
         })
       }catch(e){}
@@ -178,7 +173,7 @@ export function EHROverviewScreen(props) {
   */
   const submitData = () => {
     alert("Submitting settings...");
-    const regStrings = regions.map(function(item) {
+    const regStrings = state.regions.map(function(item) {
       return item['name']+" "+item['enabled']+"\n";
     });
     alert(regStrings.toString())
@@ -192,10 +187,18 @@ export function EHROverviewScreen(props) {
     @Chrimle
   */
   const toggleCheckbox = (index) => {
-    setRegions((prevState) => {
-      prevState[index].enabled = !prevState[index].enabled; 
-      return[...prevState]
-    })
+    
+    let enabled = state.regions[index].enabled
+    let name = state.regions[index].name
+    let updated = state.regions
+
+    updated.splice(index,1,{name:name, enabled:!enabled})
+
+    setState(prevState => ({
+      ...prevState,
+      regions: updated
+    }))
+
   } 
 
 
@@ -272,7 +275,8 @@ export function EHROverviewScreen(props) {
     const togglePopup = (enabled) => {
       setState(prevState => ({
         ...prevState,
-        modalVisible: enabled
+        modalVisible: enabled,
+        regions: [...state.regionSnapshot],
       }))
     }
 
@@ -302,7 +306,7 @@ export function EHROverviewScreen(props) {
                 <Text style={[styles.description,{padding:10}]}>Select which regions you allow to read your medical record, by checking the corresponding box. Regions you currently have given permission to are pre-filled.</Text>
                 <FlatList
                 style={styles.regionList}
-                data={regions}
+                data={state.regions}
                 numColumns={3}
                 keyExtractor={({item, index}) => index}
                 renderItem={({item, index}) => 

--- a/client/src/screens/Overview/EHROverviewScreen.js
+++ b/client/src/screens/Overview/EHROverviewScreen.js
@@ -128,10 +128,6 @@ export function EHROverviewScreen(props) {
   const [inputPhoneNr, setPhoneNr] = useState("");
   const [inputEmail, setEmail] = useState("");
 
-
-  /* This is the popup window - whether it is visible or no */ 
-  const [showWarning, setShowWarning] = useState(false);
-
   /* 
     Method for toggle the collapsing of a journal entry.
     Takes index as parameter to identify which one to toggle.
@@ -188,9 +184,15 @@ export function EHROverviewScreen(props) {
 
     }
 
+    const toggleWarning = (enabled) => {
+      setState(prevState => ({
+        ...prevState,
+        showWarning: enabled
+      }))
+    }
 
     const editContactInfo = () => {
-      setShowWarning(false)
+      toggleWarning(false)
       setEditingContactInfo(true)
       // populate input forms before editing
       setAddress(patientInfo.address)
@@ -216,7 +218,7 @@ export function EHROverviewScreen(props) {
         setEditingContactInfo(false)
       }
       else{
-        setShowWarning(true);
+        toggleWarning(true);
       }
     }
 
@@ -335,7 +337,7 @@ export function EHROverviewScreen(props) {
                   }
                 </View>
                 {
-                  editingContactInfo && showWarning &&
+                  editingContactInfo && state.showWarning &&
                   <View style={styles.contactItem}>
                     <Text style={styles.warningLabel}>Error: Input fields cannot be empty</Text>
                   </View>

--- a/client/src/screens/Overview/EHROverviewScreen.js
+++ b/client/src/screens/Overview/EHROverviewScreen.js
@@ -19,9 +19,6 @@ export function EHROverviewScreen(props) {
   const route = useRoute();
   const navigation = useNavigation();
 
-  /* TODO: Replace this in some way, need to cross-reference with Firebase with User UID */
-  const patientID = props.route.params == null ? 8701104455 : props.route.params;
-
 
   // FOR TESTING, CHANGE THIS TO "doctor" or "patient", to access the 2 views
   const placeholderRole = "patient";
@@ -42,17 +39,11 @@ export function EHROverviewScreen(props) {
     regionSnapshot: []
   }) 
 
-
-
-
-
-
-
-
-  const [patientInfo,setPatientInfo] = useState(PlaceholderValues.patient);
-
   const wipePatientData = () => {
-    setPatientInfo(PlaceholderValues.patient);
+    setState(prevState => ({
+      ...prevState,
+      patientInfo:PlaceholderValues.patient
+    }))
   }
 
   /* 
@@ -60,17 +51,17 @@ export function EHROverviewScreen(props) {
   */
     const fetchPatientData = () => {
       //alert("attempting fetch "+patientID)
-      if (patientID == patientInfo.patientId){
+      if (state.patientID == state.patientInfo.patientId){
         return;
       }
-      const patientRef = ref(database, 'Users/' + patientID);
+      const patientRef = ref(database, 'Users/' + state.patientID);
       
 
       try{
       onValue(patientRef, (snapshot) => 
       {
           if(snapshot.val() === null){
-            alert("ERROR: This patient does not exist:"+patientID)
+            alert("ERROR: This patient does not exist:"+state.patientID)
           }
           else{
             
@@ -94,7 +85,7 @@ export function EHROverviewScreen(props) {
               journalExpanded:journalIndexes,
               doctorRole:userRole=="doctor",
               patientInfo:{
-                patientId:patientID,
+                patientId:state.patientID,
                 firstName:snapshot.val().firstName,
                 lastName:snapshot.val().lastName,
                 email:snapshot.val().email,
@@ -111,27 +102,6 @@ export function EHROverviewScreen(props) {
               },
               regions:[...regionIndexes],
               regionSnapshot: [...regionIndexes],
-            }))
-
-            
-
-
-            // getPatientContactInfo
-            setPatientInfo(() => ({
-              patientId:patientID,
-              firstName:snapshot.val().firstName,
-              lastName:snapshot.val().lastName,
-              email:snapshot.val().email,
-              address:snapshot.val().address,
-              phoneNr:snapshot.val().phoneNr,
-              // getPrescriptions
-              // getDiagnoses
-              // getPermittedRegions
-              // getJournals
-              prescriptions:patientPrescriptions,
-              diagnoses:patientDiagnoses,
-              permittedRegions:patientPermittedRegions,
-              journals:patientJournals
             }))
           }
         })
@@ -210,10 +180,10 @@ export function EHROverviewScreen(props) {
   */
     const requestAddEHR = () => {
       // CHECK PRIVILEGE?
-      alert(patientInfo.patientId)
+      alert(state.patientInfo.patientId)
       // Get rid of patient data
       wipePatientData();
-      navigation.navigate("NewEntryScreen",patientID);
+      navigation.navigate("NewEntryScreen",state.patientID);
 
     }
 
@@ -235,9 +205,9 @@ export function EHROverviewScreen(props) {
       toggleWarning(false)
       toggleEditingContactInfo(true)
       // populate input forms before editing
-      setAddress(patientInfo.address)
-      setEmail(patientInfo.email)
-      setPhoneNr(patientInfo.phoneNr)
+      setAddress(state.patientInfo.address)
+      setEmail(state.patientInfo.email)
+      setPhoneNr(state.patientInfo.phoneNr)
     }
 
     const discardContactInfo = () => {
@@ -246,14 +216,14 @@ export function EHROverviewScreen(props) {
 
     const saveContactInfo = () => {
       if (validEmail(inputEmail) && validAddress(inputAddress) && validPhoneNr(inputPhoneNr)){
-        if (inputAddress !== patientInfo.address){
-          updateAddress(patientInfo.patientId,inputAddress)
+        if (inputAddress !== state.patientInfo.address){
+          updateAddress(state.patientInfo.patientId,inputAddress)
         }
-        if (inputEmail !== patientInfo.email){
-          updateEmail(patientInfo.patientId,inputEmail)
+        if (inputEmail !== state.patientInfo.email){
+          updateEmail(state.patientInfo.patientId,inputEmail)
         }
-        if (inputEmail !== patientInfo.email){
-          updatePhoneNr(patientInfo.patientId,inputPhoneNr)
+        if (inputEmail !== state.patientInfo.email){
+          updatePhoneNr(state.patientInfo.patientId,inputPhoneNr)
         }
         toggleEditingContactInfo(false)
       }
@@ -282,6 +252,8 @@ export function EHROverviewScreen(props) {
 
   // FETCH PATIENT DATA
   fetchPatientData();
+
+  alert("rerender!")
   return (
     <View>
       <Header />
@@ -332,7 +304,7 @@ export function EHROverviewScreen(props) {
               <View>
                 <View style={styles.contactItem}>
                   <Text style={styles.contactKey}>Full name: </Text>
-                  <Text style={styles.contactValue}>{patientInfo.lastName}, {patientInfo.firstName}</Text>                                  
+                  <Text style={styles.contactValue}>{state.patientInfo.lastName}, {state.patientInfo.firstName}</Text>                                  
                 </View>
                 <View style={styles.contactItem}>
                   <Text style={styles.contactKey}>Address: </Text>
@@ -345,7 +317,7 @@ export function EHROverviewScreen(props) {
                     multiline={true}
                   /></View>)
                   :
-                  (<Text style={styles.contactValue}>{patientInfo.address}</Text>)
+                  (<Text style={styles.contactValue}>{state.patientInfo.address}</Text>)
                   }
                   
                 </View>
@@ -359,7 +331,7 @@ export function EHROverviewScreen(props) {
                     placeholder="Phone number"
                   /></View>)
                   :
-                  (<Text style={styles.contactValue}>{patientInfo.phoneNr}</Text>)
+                  (<Text style={styles.contactValue}>{state.patientInfo.phoneNr}</Text>)
                   }
                   
                 </View>
@@ -374,7 +346,7 @@ export function EHROverviewScreen(props) {
                     keyboardType="email-address"
                   /></View>)
                   :
-                  (<Text style={styles.contactValue}>{patientInfo.email}</Text>)
+                  (<Text style={styles.contactValue}>{state.patientInfo.email}</Text>)
                   }
                 </View>
                 {
@@ -432,7 +404,7 @@ export function EHROverviewScreen(props) {
           <View style={styles.container}>
             <Text style={styles.header}>Prescriptions</Text>
             <FlatList
-              data={patientInfo.prescriptions}
+              data={state.patientInfo.prescriptions}
               keyExtractor={({item, index}) => index}
               renderItem={({item, index}) => (
                 <View key={index}>
@@ -444,7 +416,7 @@ export function EHROverviewScreen(props) {
           <View style={styles.container}>
             <Text style={styles.header}>Diagnoses</Text>
             <FlatList
-              data={patientInfo.diagnoses}
+              data={state.patientInfo.diagnoses}
               keyExtractor={({item, index}) => index}
               renderItem={({item, index}) => (
                 <View key={index}>
@@ -459,7 +431,7 @@ export function EHROverviewScreen(props) {
               <Text style={styles.header}>Past record entries</Text>
               <FlatList
               style={{width:"100%"}}
-              data={patientInfo.journals}
+              data={state.patientInfo.journals}
               keyExtractor={({item, index}) => index}
               ListHeaderComponent={
                 <View style={styles.journalListItem}>

--- a/client/src/screens/Overview/EHROverviewScreen.js
+++ b/client/src/screens/Overview/EHROverviewScreen.js
@@ -26,6 +26,26 @@ export function EHROverviewScreen(props) {
   // FOR TESTING, CHANGE THIS TO "doctor" or "patient", to access the 2 views
   const placeholderRole = "patient";
 
+  const [state, setState] = useState({
+    doctorRole: false,
+    regions: [],
+    patientInfo: PlaceholderValues.patient,
+    patientID: props.route.params == null ? 8701104455 : props.route.params,
+    journalExpanded: [],
+    editingContactInfo: false,
+    inputAddress: "",
+    inputAddress: "",
+    inputPhoneNr: "",
+    inputEmail: "",
+    modalVisible: false,
+    showWarning: false,
+  }) 
+
+
+
+
+
+
   const [doctorRole,setDoctorRole] = useState(false);
   const [regions,setRegions] = useState([]);
 
@@ -110,9 +130,6 @@ export function EHROverviewScreen(props) {
 
 
   /* This is the popup window - whether it is visible or no */ 
-  const [modalVisible, setModalVisible] = useState(false);
-
-  /* This is the popup window - whether it is visible or no */ 
   const [showWarning, setShowWarning] = useState(false);
 
   /* 
@@ -139,7 +156,8 @@ export function EHROverviewScreen(props) {
       return item['name']+" "+item['enabled']+"\n";
     });
     alert(regStrings.toString())
-    setModalVisible(false);
+
+    togglePopup(false)
   }
 
   /* 
@@ -212,6 +230,12 @@ export function EHROverviewScreen(props) {
       return phoneNr !== ""
     }
 
+    const togglePopup = (enabled) => {
+      setState(prevState => ({
+        ...prevState,
+        modalVisible: enabled
+      }))
+    }
 
   // FETCH PATIENT DATA
   fetchPatientData();
@@ -222,12 +246,12 @@ export function EHROverviewScreen(props) {
         <Modal
           animationType="none"
           transparent={true}
-          visible={modalVisible}
+          visible={state.modalVisible}
           horizontal={false}
           numColumns={3}
           onRequestClose={() => {
             alert("The submission was cancelled.");
-            setModalVisible(!modalVisible);
+            togglePopup(false);
           }}
         >
           <View style={{width:"100%", height:"100%", backgroundColor:'rgba(0,0,0,0.80)', justifyContent:"center", alignItems:"center",}}>
@@ -252,7 +276,7 @@ export function EHROverviewScreen(props) {
                 }/>
               </View>
               <View style={{flex:1,flexDirection:"row",borderTopColor:"grey",borderTopWidth:1,alignItems:"center",justifyContent:"space-evenly"}}>
-                <TouchableOpacity onPress={() => setModalVisible(false)} style={[styles.popupButton,styles.greyButton]}><Text>Discard changes</Text></TouchableOpacity>
+                <TouchableOpacity onPress={() => togglePopup(false)} style={[styles.popupButton,styles.greyButton]}><Text>Discard changes</Text></TouchableOpacity>
                 <TouchableOpacity onPress={() => submitData()} style={[styles.popupButton,styles.primaryButton]}><Text style={{color:"white"}}>Submit changes</Text></TouchableOpacity>
               </View>
             </View>
@@ -357,7 +381,7 @@ export function EHROverviewScreen(props) {
               <View style={styles.container}>
                 <Text style={styles.header}>Data Privacy</Text>
                 <Text style={styles.description}>Configure what regions can access and view your medical record. You can change this at any time.</Text>
-                <ThemeButton labelText="Configure" labelSize={25} iconName="eye-outline" iconSize={30} bWidth={200} bHeight={60} onPress={() => setModalVisible(true)}/>
+                <ThemeButton labelText="Configure" labelSize={25} iconName="eye-outline" iconSize={30} bWidth={200} bHeight={60} onPress={() => togglePopup(true)}/>
               </View>
             }
         </View>

--- a/client/src/screens/Overview/EHROverviewScreen.js
+++ b/client/src/screens/Overview/EHROverviewScreen.js
@@ -191,9 +191,16 @@ export function EHROverviewScreen(props) {
       }))
     }
 
+    const toggleEditingContactInfo = (enabled) => {
+      setState(prevState => ({
+        ...prevState,
+        editingContactInfo: enabled
+      }))
+    }
+
     const editContactInfo = () => {
       toggleWarning(false)
-      setEditingContactInfo(true)
+      toggleEditingContactInfo(true)
       // populate input forms before editing
       setAddress(patientInfo.address)
       setEmail(patientInfo.email)
@@ -201,7 +208,7 @@ export function EHROverviewScreen(props) {
     }
 
     const discardContactInfo = () => {
-      setEditingContactInfo(false)
+      toggleEditingContactInfo(false)
     }
 
     const saveContactInfo = () => {
@@ -215,7 +222,7 @@ export function EHROverviewScreen(props) {
         if (inputEmail !== patientInfo.email){
           updatePhoneNr(patientInfo.patientId,inputPhoneNr)
         }
-        setEditingContactInfo(false)
+        toggleEditingContactInfo(false)
       }
       else{
         toggleWarning(true);
@@ -295,7 +302,7 @@ export function EHROverviewScreen(props) {
                 </View>
                 <View style={styles.contactItem}>
                   <Text style={styles.contactKey}>Address: </Text>
-                  { editingContactInfo ?
+                  { state.editingContactInfo ?
                   (<View style={styles.contactValue}><TextInput
                     style={styles.contactInput}
                     onChangeText={setAddress}
@@ -310,7 +317,7 @@ export function EHROverviewScreen(props) {
                 </View>
                 <View style={styles.contactItem}>
                   <Text style={styles.contactKey}>Phone: </Text>
-                  { editingContactInfo ?
+                  { state.editingContactInfo ?
                   (<View style={styles.contactValue}><TextInput
                     style={styles.contactInput}
                     onChangeText={setPhoneNr}
@@ -324,7 +331,7 @@ export function EHROverviewScreen(props) {
                 </View>
                 <View style={styles.contactItem}>
                   <Text style={styles.contactKey}>Email: </Text>
-                  { editingContactInfo ?
+                  { state.editingContactInfo ?
                   (<View style={styles.contactValue}><TextInput
                     style={styles.contactInput}
                     onChangeText={setEmail}
@@ -337,7 +344,7 @@ export function EHROverviewScreen(props) {
                   }
                 </View>
                 {
-                  editingContactInfo && state.showWarning &&
+                  state.editingContactInfo && state.showWarning &&
                   <View style={styles.contactItem}>
                     <Text style={styles.warningLabel}>Error: Input fields cannot be empty</Text>
                   </View>
@@ -345,7 +352,7 @@ export function EHROverviewScreen(props) {
                 
                 { !doctorRole &&
                 <View style={styles.contactItem}>
-                  { editingContactInfo ?
+                  { state.editingContactInfo ?
                   <>
                   <ThemeButton 
                     labelText="Discard Changes" 

--- a/client/src/screens/Overview/EHROverviewScreen.js
+++ b/client/src/screens/Overview/EHROverviewScreen.js
@@ -46,7 +46,7 @@ export function EHROverviewScreen(props) {
 
 
 
-  const [doctorRole,setDoctorRole] = useState(false);
+
   const [regions,setRegions] = useState([]);
 
   const [patientInfo,setPatientInfo] = useState(PlaceholderValues.patient);
@@ -81,8 +81,6 @@ export function EHROverviewScreen(props) {
             const patientPermittedRegions = PlaceholderValues.permittedRegions;
             const patientPrescriptions    = PlaceholderValues.prescriptions;
             const patientDiagnoses        = PlaceholderValues.diagnoses;
-            
-            setDoctorRole(userRole == "doctor")
 
             let journalIndexes = [];
             patientJournals.forEach(() => journalIndexes.push(false))
@@ -382,7 +380,7 @@ export function EHROverviewScreen(props) {
                   </View>
                 }
                 
-                { !doctorRole &&
+                { !state.doctorRole &&
                 <View style={styles.contactItem}>
                   { state.editingContactInfo ?
                   <>
@@ -411,7 +409,7 @@ export function EHROverviewScreen(props) {
                 }
               </View>
             </View>
-            { doctorRole ?
+            { state.doctorRole ?
               // Doctor Version
               <View style={styles.container}>
                 <Text style={styles.header}>Add EHR entry</Text>

--- a/client/src/screens/Overview/EHROverviewScreen.js
+++ b/client/src/screens/Overview/EHROverviewScreen.js
@@ -253,7 +253,6 @@ export function EHROverviewScreen(props) {
   // FETCH PATIENT DATA
   fetchPatientData();
 
-  alert("rerender!")
   return (
     <View>
       <Header />


### PR DESCRIPTION
### Seriously reduces the number of rerenders in the EHROverview screen!
_Down to a total of 2 renders on start up_
1. The initial one, this one is completely blank, may need to hide that with a loading thing? :thinking: 
2. The second render is after the patient data has been fetched and stored in a new state. This new render will reflect that by displaying patient data.

Recall, if any state ever changes, a re-render will be carried out. So, if the patient data was fetched and set, it would trigger a re-render, the same for the list of regions and the journal list (these are tied to the interactive components).

_"So what about when we toggle to see details of a journal entry?"_
This **will** trigger a rerender, **but**, it will not indirectly trigger any changes to any other states (which would trigger a rerender).

### Additionally:
When a user makes changes to the region settings, and they chose to 'discard', these changes are actually discarded and won't show up again when reopening that popup window.