### PR TITLE
Loading screen to hide blank page in EHROverview

### DIFF
--- a/client/src/screens/Overview/EHROverviewScreen.js
+++ b/client/src/screens/Overview/EHROverviewScreen.js
@@ -363,19 +363,9 @@ export function EHROverviewScreen(props) {
           animationType="none"
           transparent={true}
           visible={state.isLoading}
-          horizontal={false}
-        >
-          <View
-            style={{
-              position:"absolute",
-              marginTop: theme.NAVBAR_HEIGHT,
-              width:"100%",
-              height: "100%",
-              backgroundColor: "white",
-              alignItems: "center",
-            }}
-          >
-            <Text style={[{marginTop:250, fontSize:36, color:theme.PRIMARY_COLOR,textAlign:"center"}]}>Loading patient data...</Text>
+          horizontal={false}>
+          <View style={styles.loadingOverlay}>
+            <Text style={styles.loadingText}>Loading patient data...</Text>
             <ActivityIndicator size="large" color={theme.PRIMARY_COLOR}/>
           </View>
         </Modal>

--- a/client/src/screens/Overview/EHROverviewScreen.js
+++ b/client/src/screens/Overview/EHROverviewScreen.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useRoute, useNavigation } from "@react-navigation/native";
-import { Text, View, Modal, TextInput } from "react-native";
+import { Text, View, Modal, TextInput, ActivityIndicator } from "react-native";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header/Header";
 import styles from "./styles";
@@ -40,6 +40,7 @@ export function EHROverviewScreen(props) {
     modalVisible: false,
     showWarning: false,
     regionSnapshot: [],
+    isLoading: true,
   });
 
 
@@ -93,6 +94,7 @@ export function EHROverviewScreen(props) {
 
           setState((prevState) => ({
             ...prevState,
+            isLoading: false,
             patientID: state.doctorRole ? props.route.params : userSSN,
             journalExpanded: journalIndexes,
             patientInfo: {
@@ -355,6 +357,26 @@ export function EHROverviewScreen(props) {
                 </TouchableOpacity>
               </View>
             </View>
+          </View>
+        </Modal>
+        <Modal
+          animationType="none"
+          transparent={true}
+          visible={state.isLoading}
+          horizontal={false}
+        >
+          <View
+            style={{
+              position:"absolute",
+              marginTop: theme.NAVBAR_HEIGHT,
+              width:"100%",
+              height: "100%",
+              backgroundColor: "white",
+              alignItems: "center",
+            }}
+          >
+            <Text style={[{marginTop:250, fontSize:36, color:theme.PRIMARY_COLOR,textAlign:"center"}]}>Loading patient data...</Text>
+            <ActivityIndicator size="large" color={theme.PRIMARY_COLOR}/>
           </View>
         </Modal>
         <Text style={styles.contentHeader}>Patient Overview</Text>

--- a/client/src/screens/Overview/styles.js
+++ b/client/src/screens/Overview/styles.js
@@ -190,6 +190,20 @@ const styles = StyleSheet.create({
         paddingVertical:5,
         paddingHorizontal:10,
         textAlign:"center"
+    },
+    loadingOverlay:{
+        position:"absolute",
+        marginTop: theme.NAVBAR_HEIGHT,
+        width:"100%",
+        height: "100%",
+        backgroundColor: "white",
+        alignItems: "center",
+    },
+    loadingText:{
+        marginTop:250,
+        fontSize:36, 
+        color:theme.PRIMARY_COLOR,
+        textAlign:"center"
     }
 });
 


### PR DESCRIPTION
The first render is now hidden behind a loading screen. This screen disappears the moment the second render completes. This means patients will not see "Add EHR" and, doctors won't see "Configure". This also hides the fact that the contact info is blank in the beginning.

### Changes:
Added a `<Modal>` to EHROverview - with the text "Loading patient data" and a `<ActivityIndicator>`
Added associated styling to styles.js

![image](https://user-images.githubusercontent.com/28791817/161740400-acf873cb-711a-4053-b60e-4acd11655ed4.png)
