### PR TITLE
Pin Navbar to top

### DIFF
--- a/client/src/components/Footer.js
+++ b/client/src/components/Footer.js
@@ -24,7 +24,7 @@ const styles = StyleSheet.create({
     footer : {
         position: 'fixed',
         bottom: 0,
-        height: 40,
+        height: theme.FOOTER_HEIGHT,
         width: '100%',
         backgroundColor: theme.SECONDARY_COLOR,
         textAlign: 'center',

--- a/client/src/components/Header/Header.js
+++ b/client/src/components/Header/Header.js
@@ -63,6 +63,9 @@ const Header = () => {
 
 const styles = StyleSheet.create({
   navbarContainer:{
+    position:"fixed",
+    top:0,
+    left:0,
     width: '100%',
     height: theme.NAVBAR_HEIGHT,
     backgroundColor: theme.SECONDARY_COLOR,

--- a/client/src/screens/LoginScreen/LoginScreen.js
+++ b/client/src/screens/LoginScreen/LoginScreen.js
@@ -31,7 +31,7 @@ export function LoginScreen() {
 
   return (
     <View style={styles.main}>
-      <Header />
+      
       <View style={styles.content}>
         <View style={styles.splitContainer}>
           <View
@@ -107,6 +107,7 @@ export function LoginScreen() {
           </View>
         </View>
       </View>
+      <Header />
       <Footer />
     </View>
   );

--- a/client/src/screens/LoginScreen/styles.js
+++ b/client/src/screens/LoginScreen/styles.js
@@ -8,6 +8,7 @@ const styles = StyleSheet.create({
       backgroundColor: "white",
     },
     content: {
+      top: theme.NAVBAR_HEIGHT,
       width: '100%',
       height: theme.CONTENT_HEIGHT,
     },

--- a/client/src/screens/MiscScreens/styles.js
+++ b/client/src/screens/MiscScreens/styles.js
@@ -3,6 +3,7 @@ import theme from "../../theme.style";
 
 const styles = StyleSheet.create({
     content:{
+        top:theme.NAVBAR_HEIGHT,
         padding:50,
         width:"100%",
         height:"100%",

--- a/client/src/screens/Overview/EHROverviewScreen.js
+++ b/client/src/screens/Overview/EHROverviewScreen.js
@@ -259,7 +259,7 @@ export function EHROverviewScreen(props) {
 
   return (
     <View>
-      <Header />
+      
       <View style={styles.content}>
         <Modal
           animationType="none"
@@ -656,6 +656,7 @@ export function EHROverviewScreen(props) {
         </View>
       </View>
       <Footer />
+      <Header />
     </View>
   );
 }

--- a/client/src/screens/Overview/styles.js
+++ b/client/src/screens/Overview/styles.js
@@ -3,8 +3,9 @@ import theme from "../../theme.style";
 
 const styles = StyleSheet.create({
     content:{
+        top:theme.NAVBAR_HEIGHT,
+        height:"110%",
         width:"100%",
-        height:"100%",
     },
     contentHeader:{
         color:theme.PRIMARY_COLOR,

--- a/client/src/screens/StaffScreens/NewEntryScreen/NewEntryScreen.js
+++ b/client/src/screens/StaffScreens/NewEntryScreen/NewEntryScreen.js
@@ -239,7 +239,7 @@ export function NewEntryScreen(props) {
 
   return (
     <View style={styles.main}>
-      <Header/>
+      
       <View style={styles.content}>
         <Modal
           animationType="none"
@@ -412,6 +412,7 @@ export function NewEntryScreen(props) {
           </View>
         </View>
       </View>
+      <Header/>
       <Footer/>
     </View>
   );

--- a/client/src/screens/StaffScreens/PatientSearchScreen/styles.js
+++ b/client/src/screens/StaffScreens/PatientSearchScreen/styles.js
@@ -3,6 +3,7 @@ import theme from "../../../theme.style";
 
 const styles = StyleSheet.create({
     content:{
+        top:theme.NAVBAR_HEIGHT,
         padding:50,
         width:"100%",
         height:"100%",

--- a/client/src/styles.js
+++ b/client/src/styles.js
@@ -9,6 +9,7 @@ const styles = StyleSheet.create({
     backgroundColor: "white",
   },
   content: {
+    top:theme.NAVBAR_HEIGHT,
     width: '100%',
     height: theme.CONTENT_HEIGHT,
   },

--- a/client/src/theme.style.js
+++ b/client/src/theme.style.js
@@ -1,6 +1,7 @@
 export default {
     PRIMARY_COLOR: "#1D6453",
     SECONDARY_COLOR: "#E4F5F1",
-    CONTENT_HEIGHT: 700,
     NAVBAR_HEIGHT: 90,
+    FOOTER_HEIGHT: 40,
+    CONTENT_HEIGHT: 800,
   };


### PR DESCRIPTION
Pins the navbar (`<Header>`) to the top of the screen - making it stay in place when scrolling. This solves #43.

Because newly found knowledge about the render-order, and what overlaps what, the `<Header>` components have been moved down to be drawn last/just before the `<Footer>`.

Also adjusted some heights of screens, so #42 may also be solved. 