### PR TITLE
Frontend encrypts & decrypts EHRs

### DIFF
--- a/client/Crypto/crypt.js
+++ b/client/Crypto/crypt.js
@@ -69,8 +69,8 @@ function decryptEHR(record_key, EHR, privateKey) {
  * @param {*} publicKeyFile The public key used to encrypt the record key.
  * @returns Encrypted record key.
  */
-function encryptRecordKey(record_key, publicKeyFile) {
-  const publicKey = fs.readFileSync(publicKeyFile, "utf8");
+function encryptRecordKey(record_key, publicKey) {
+  //const publicKey = fs.readFileSync(publicKeyFile, "utf8");
 
   // publicEncrypt() method with its parameters
   const encrypted = crypto.publicEncrypt(
@@ -87,8 +87,8 @@ function encryptRecordKey(record_key, publicKeyFile) {
  * @param {*} privateKeyFile A users private key.
  * @returns The decrypted record key.
  */
-function decryptRecordKey(record_key, privateKeyFile) {
-  const privateKey = fs.readFileSync(privateKeyFile, "utf8");
+function decryptRecordKey(record_key, privateKey) {
+  //const privateKey = fs.readFileSync(privateKeyFile, "utf8");
 
   // privateDecrypt() method with its parameters
   const decrypted = crypto.privateDecrypt(

--- a/client/Crypto/crypt.js
+++ b/client/Crypto/crypt.js
@@ -15,9 +15,9 @@ const algorithm = "aes-256-gcm";
  * @param {*} medPers_privKey The medical personnels' private key that writes the EHR.
  * @returns The IV for the encryption and the encrypted EHR.
  */
-function encryptEHR(record_key, EHR, medPers_privKey) {
+function encryptEHR(record_key, medPers_privKey, content, iv) {
   const decrypted_record_key = decryptRecordKey(record_key, medPers_privKey);
-  const iv = crypto.randomBytes(32);
+  //const iv = crypto.randomBytes(32);
 
   let cipher = crypto.createCipheriv(
     algorithm,
@@ -25,7 +25,7 @@ function encryptEHR(record_key, EHR, medPers_privKey) {
     iv
   );
 
-  let encryptedEHR = cipher.update(Buffer.from(EHR, "base64"));
+  let encryptedEHR = cipher.update(Buffer.from(content, "base64"));
   encryptedEHR = Buffer.concat([encryptedEHR, cipher.final()]);
 
   return {
@@ -44,6 +44,7 @@ function encryptEHR(record_key, EHR, medPers_privKey) {
  */
 function decryptEHR(record_key, EHR, privateKey) {
   const decrypted_record_key = decryptRecordKey(record_key, privateKey);
+  console.log("decrypt key works")
   let iv = Buffer.from(EHR.iv, "base64");
   let encryptedEHR = Buffer.from(EHR.encryptedData, "base64");
 

--- a/client/Crypto/crypt.js
+++ b/client/Crypto/crypt.js
@@ -25,12 +25,12 @@ function encryptEHR(record_key, EHR, medPers_privKey) {
     iv
   );
 
-  let encryptedEHR = cipher.update(Buffer.from(EHR, "base64"));
+  let encryptedEHR = cipher.update(Buffer.from(EHR, "utf8"));
   encryptedEHR = Buffer.concat([encryptedEHR, cipher.final()]);
 
   return {
     iv: iv.toString("base64"),
-    encryptedData: encryptedEHR.toString("base64"),
+    encryptedData: encryptedEHR.toString("hex"),
     Tag: cipher.getAuthTag(),
   };
 }
@@ -49,7 +49,7 @@ function decryptEHR(record_key, EHR, privateKey) {
   const decrypted_record_key = decryptRecordKey(record_key, privateKey);
   //console.log("###########After")
   let iv = Buffer.from(EHR.iv, "base64");
-  let encryptedEHR = Buffer.from(EHR.encryptedData, "base64");
+  let encryptedEHR = Buffer.from(EHR.encryptedData, "hex");
 
   let decipher = crypto.createDecipheriv(
     algorithm,
@@ -59,11 +59,11 @@ function decryptEHR(record_key, EHR, privateKey) {
   decipher.setAuthTag(EHR.Tag);
 
   // Updating encrypted text
-  let decryptedEHR = decipher.update(encryptedEHR, "base64");
+  let decryptedEHR = decipher.update(encryptedEHR);
   decryptedEHR = Buffer.concat([decryptedEHR, decipher.final()]);
   
   // returns data after decryption
-  return decryptedEHR.toString("base64").toString("utf-8");
+  return decryptedEHR.toString();
 }
 
 /**

--- a/client/Crypto/crypt.js
+++ b/client/Crypto/crypt.js
@@ -1,27 +1,26 @@
 const crypto = require("crypto");
-const fs = require("fs");
 
 /**
  * Methods for encrypting/decrypting EHR and record keys.
- * @author David Zamanian, Nils Johnsson, Wendy Pau
+ * @author David Zamanian, Nils Johnsson, Wendy Pau, Christopher Molin
  */
 
 const algorithm = "aes-256-gcm";
 
 /**
  * Encrypts the EHR with the record key using the AES crypto algorithm.
- * @param {*} record_key Encrypted record_key retrieved from DB.
- * @param {*} EHR The EHR json file to be encrypted.
- * @param {*} medPers_privKey The medical personnels' private key that writes the EHR.
- * @returns The IV for the encryption and the encrypted EHR.
+ * @param {string} recordKey Encrypted record_key retrieved from DB.
+ * @param {string} EHR The EHR text content to be encrypted.
+ * @param {string} privateKey The medical personnels' private key that writes the EHR.
+ * @returns {{iv: string, Tag: Buffer, encryptedData: string}} The IV for the encryption and the encrypted EHR.
  */
-function encryptEHR(record_key, EHR, medPers_privKey) {
-  const decrypted_record_key = decryptRecordKey(record_key, medPers_privKey);
+function encryptEHR(recordKey, EHR, privateKey) {
+  const decryptedRecordKey = decryptRecordKey(recordKey, privateKey);
   const iv = crypto.randomBytes(32);
 
   let cipher = crypto.createCipheriv(
     algorithm,
-    Buffer.from(decrypted_record_key, "base64"),
+    Buffer.from(decryptedRecordKey, "base64"),
     iv
   );
 
@@ -37,23 +36,21 @@ function encryptEHR(record_key, EHR, medPers_privKey) {
 
 /**
  * Decrypts the EHR using the record key.
- * @param {*} record_key Encrypted record_key retrieved from DB.
- * @param {*} EHR Contains the IV and encrypted EHR.
- * @param {*} EHR.iv
- * @param {*} EHR.Tag
- * @param {*} privateKey Permissioned private key used to decrypt the record key.
- * @returns The decrypted EHR in string.
+ * @param {string} recordKey Encrypted record_key retrieved from DB.
+ * @param {{iv: Buffer, Tag: Buffer, encryptedData: string}} EHR Contains the IV and encrypted EHR.
+ * @param {string} privateKey Permissioned private key used to decrypt the record key.
+ * @returns {string} The decrypted EHR in string.
  */
-function decryptEHR(record_key, EHR, privateKey) {
-  //console.log("###########Before")
-  const decrypted_record_key = decryptRecordKey(record_key, privateKey);
-  //console.log("###########After")
+function decryptEHR(recordKey, EHR, privateKey) {
+
+  const decryptedRecordKey = decryptRecordKey(recordKey, privateKey);
+
   let iv = Buffer.from(EHR.iv, "base64");
   let encryptedEHR = Buffer.from(EHR.encryptedData, "hex");
 
   let decipher = crypto.createDecipheriv(
     algorithm,
-    Buffer.from(decrypted_record_key, "base64"),
+    Buffer.from(decryptedRecordKey, "base64"),
     iv
   );
   decipher.setAuthTag(EHR.Tag);
@@ -69,17 +66,16 @@ function decryptEHR(record_key, EHR, privateKey) {
 /**
  * Encrypts the record key using asymmetric encryption. Also used to give permission to the EHR by which users' public key is used.
  * Creating a function to encrypt string
- * @param {*} record_key A generated symmetric record key.
- * @param {*} publicKeyFile The public key used to encrypt the record key.
- * @returns Encrypted record key.
+ * @param {string} recordKey A generated symmetric record key.
+ * @param {string} publicKey The public key used to encrypt the record key.
+ * @returns {string} Encrypted record key.
  */
-function encryptRecordKey(record_key, publicKey) {
-  //const publicKey = fs.readFileSync(publicKeyFile, "utf8");
+function encryptRecordKey(recordKey, publicKey) {
 
   // publicEncrypt() method with its parameters
   const encrypted = crypto.publicEncrypt(
     publicKey,
-    Buffer.from(record_key, "base64")
+    Buffer.from(recordKey, "base64")
   );
   return encrypted.toString("base64");
 }
@@ -87,17 +83,17 @@ function encryptRecordKey(record_key, publicKey) {
 /**
  * Decrypts the record key using asymmetric encryption.
  * // Creating a function to decrypt string
- * @param {*} record_key Encrypted record key.
- * @param {*} privateKeyFile A users private key.
- * @returns The decrypted record key.
+ * @param {string} recordKey Encrypted record key.
+ * @param {string} privateKey A users private key.
+ * @returns {string} The decrypted record key.
  */
-function decryptRecordKey(record_key, privateKey) {
+function decryptRecordKey(recordKey, privateKey) {
   //const privateKey = fs.readFileSync(privateKeyFile, "utf8");
 
   // privateDecrypt() method with its parameters
   const decrypted = crypto.privateDecrypt(
     privateKey,
-    Buffer.from(record_key, "base64")
+    Buffer.from(recordKey, "base64")
   );
   return decrypted.toString("base64");
 }

--- a/client/Crypto/crypt.js
+++ b/client/Crypto/crypt.js
@@ -61,7 +61,7 @@ function decryptEHR(record_key, EHR, privateKey) {
   decryptedEHR = Buffer.concat([decryptedEHR, decipher.final()]);
 
   // returns data after decryption
-  return decryptedEHR.toString();
+  return decryptedEHR.toString("base64");
 }
 
 /**

--- a/client/Crypto/crypt.js
+++ b/client/Crypto/crypt.js
@@ -45,7 +45,9 @@ function encryptEHR(record_key, EHR, medPers_privKey) {
  * @returns The decrypted EHR in string.
  */
 function decryptEHR(record_key, EHR, privateKey) {
+  console.log("###########Before")
   const decrypted_record_key = decryptRecordKey(record_key, privateKey);
+  console.log("###########After")
   let iv = Buffer.from(EHR.iv, "base64");
   let encryptedEHR = Buffer.from(EHR.encryptedData, "base64");
 
@@ -59,9 +61,9 @@ function decryptEHR(record_key, EHR, privateKey) {
   // Updating encrypted text
   let decryptedEHR = decipher.update(encryptedEHR, "base64");
   decryptedEHR = Buffer.concat([decryptedEHR, decipher.final()]);
-
+  
   // returns data after decryption
-  return decryptedEHR.toString("base64");
+  return decryptedEHR.toString("base64").toString("utf-8");
 }
 
 /**

--- a/client/Crypto/crypt.js
+++ b/client/Crypto/crypt.js
@@ -45,9 +45,9 @@ function encryptEHR(record_key, EHR, medPers_privKey) {
  * @returns The decrypted EHR in string.
  */
 function decryptEHR(record_key, EHR, privateKey) {
-  console.log("###########Before")
+  //console.log("###########Before")
   const decrypted_record_key = decryptRecordKey(record_key, privateKey);
-  console.log("###########After")
+  //console.log("###########After")
   let iv = Buffer.from(EHR.iv, "base64");
   let encryptedEHR = Buffer.from(EHR.encryptedData, "base64");
 

--- a/client/src/Helpers/ehrService.js
+++ b/client/src/Helpers/ehrService.js
@@ -132,27 +132,24 @@ export default class EHRService{
             
             for (const file of fetchedFiles){
                 let decrypted;
-                console.log("Fetched: "+file.name)
+                //console.log("testing:"+file.name+" "+await file.text())
+                let fileContent = await file.text();
+                console.log(fileContent)
+                let tag = fileContent.slice(0,24);
+                let iv = fileContent.slice(24,68);
+                let encrypted = fileContent.slice(68);
+                decrypted = await this.decrypt(encrypted, tag, iv);
                 if(file.name == "prescriptions.json"){
-                    // Decrypt
-                    
-                    decrypted = await this.decrypt(await file.text(),PlaceholderValues.tagPrescriptions, PlaceholderValues.ivPrescriptions);
-                    
                     // Parse
-                    //prescriptions = prescriptions.concat(await this.parseIntoArray(decrypted));
+                    prescriptions = prescriptions.concat(await this.parseIntoArray(decrypted));
                 }
                 else if(file.name == "diagnoses.json"){
-                    // Decrypt
-                    decrypted = await this.decrypt(await file.text(), PlaceholderValues.tagDiagnoses, PlaceholderValues.ivDiagnoses);
                     // Parse
-                    //diagnoses = diagnoses.concat(await this.parseIntoArray(decrypted));
+                    diagnoses = diagnoses.concat(await this.parseIntoArray(decrypted));
                 }
                 else{
-                    // For uploading
-                    decrypted = await this.decrypt(await file.text(), PlaceholderValues.tagEHR, PlaceholderValues.ivEHR);
-                    //finalFiles.push(file)
+                    finalFiles.push(file)
                 }
-                //console.log("after:"+decrypted)
             }
             
 
@@ -222,8 +219,9 @@ export default class EHRService{
     static async getEHR(patientID){
 
         // TODO: Look up correct CID with patientID
-        let cid = "bafybeiaghgh4wrgon7dk3yslq7aokkpc6s4rtn45oto3gqcd6mclvzshtq";
+        let cid = PlaceholderValues.ipfsCID;
 
+        console.log(cid)
         let apiToken = await EHRService.getWeb3StorageToken();
 
         let fs = new FileService(apiToken);
@@ -239,22 +237,22 @@ export default class EHRService{
 
         for (const file of fetchedFiles){
             let decrypted;
-            console.log("testing:"+file.name+" "+await file.text())
+            //console.log("testing:"+file.name+" "+await file.text())
+            let fileContent = await file.text();
+            console.log(fileContent)
+            let tag = fileContent.slice(0,24);
+            let iv = fileContent.slice(24,68);
+            let encrypted = fileContent.slice(68);
+            decrypted = await this.decrypt(encrypted, tag, iv);
             if(file.name == "prescriptions.json"){
-                // Decrypt
-                decrypted = await this.decrypt(await file.text());
                 // Parse
                 EHR.prescriptions = EHR.prescriptions.concat(await this.parseIntoArray(decrypted));
             }
             else if(file.name == "diagnoses.json"){
-                // Decrypt
-                decrypted = await this.decrypt(await file.text());
                 // Parse
                 EHR.diagnoses = EHR.diagnoses.concat(await this.parseIntoArray(decrypted));
             }
             else{
-                // Decrypt
-                decrypted = await this.decrypt(await file.text());
                 // Parse
                 EHR.journals = EHR.journals.concat(await this.parseIntoArray(decrypted));
             }
@@ -304,8 +302,11 @@ export default class EHRService{
         console.log("IV:"+x.iv.toString("base64"));
         console.log("Data:"+x.encryptedData);
         console.log("----------------------------------")
-        return x.encryptedData;
+
+        let result = "";
+        result = result.concat(x.Tag.toString("base64"),x.iv.toString("base64"),x.encryptedData);
         
+        return result;
         
     }
     /**

--- a/client/src/Helpers/ehrService.js
+++ b/client/src/Helpers/ehrService.js
@@ -314,27 +314,45 @@ export default class EHRService{
      * @returns {Promise<string>}
      */
     static async decrypt(content, tag, iv){
+        
         /*
         console.log("before encryptRecordKey")
         let x = crypt.decryptRecordKey(PlaceholderValues.recordKey,PlaceholderValues.privateKey)
         console.log(x)
         return "no :)";
         */
+
+        let privateKey = PlaceholderValues.medicPrivateKey;
+        let ivBuffer = Buffer.from(iv, "base64");
+        let tagBuffer = Buffer.from(tag,"base64");
+
+        console.log("----------------")
+        console.log("ATTEMPTING DECRYPT")
+        console.log("DATA:")
+        console.log(content)
+        console.log("IV:")
+        console.log(ivBuffer.toString("base64"))
+        console.log("TAG:")
+        console.log(tagBuffer.toString("base64"))
         
-        console.log("trying to decrypt:\n"+content+"\nIV:\n"+Buffer.from(iv,"base64").toString("base64")+"\nTag:\n"+tag)
+
+
         let EHR = {
-            iv: Buffer.from(iv, "base64"),
+            iv: ivBuffer,
             encryptedData: content,
-            Tag: Buffer.from(tag,"base64")
+            Tag: tagBuffer
           }
         
         
         
-        return crypt.decryptEHR(
+        let x = crypt.decryptEHR(
             PlaceholderValues.recordKey,
             EHR,
-            PlaceholderValues.privateKey).toString("base64")
-        
+            privateKey)
+
+        console.log("DECRYPTED DATA:")
+        console.log(x)
+        return x;
     }
 
     /**

--- a/client/src/Helpers/ehrService.js
+++ b/client/src/Helpers/ehrService.js
@@ -119,15 +119,21 @@ export default class EHRService{
                 diagnoses
             )
 
-            // FETCH OLD FILES
-            let oldCID = PlaceholderValues.ipfsCID;
-            console.log("Attempting Fetch")
-            let fetchedFiles = await fs.fetchEHRFiles(oldCID);
-            console.log("Fetch success, found "+fetchedFiles.length+" files!")
-
             let oldFiles = [];
 
             let finalFiles = [];
+
+            
+            
+            // FETCH OLD FILES
+            let oldCID = PlaceholderValues.ipfsCID;
+            console.log("Attempting Fetch")
+            let filesAndIndex = await fs.fetchEHRFiles(oldCID);
+            let fetchedFiles = filesAndIndex.files
+            let index = filesAndIndex.index
+            console.log("Fetch success, found "+fetchedFiles.length+" files!")
+
+            
             
             
             for (const file of fetchedFiles){
@@ -167,7 +173,7 @@ export default class EHRService{
 
 
             // Create JSON files
-            let ehrFile = await FileService.createJSONFile(encryptedEHR,"EHR_"+objectEHR.date.toString().slice(0, 19));
+            let ehrFile = await FileService.createJSONFile(encryptedEHR,"EHR_"+index);
             let prescriptionsFile = await FileService.createJSONFile(encryptedPrescriptions,"prescriptions");
             let diagnosesFile = await FileService.createJSONFile(encryptedDiagnoses,"diagnoses");
 
@@ -203,6 +209,7 @@ export default class EHRService{
             } else if (e instanceof FetchFileContentError){
                 return "Error";
             } else{
+                console.log(e)
                 return "Error";
             }
         }

--- a/client/src/Helpers/ehrService.js
+++ b/client/src/Helpers/ehrService.js
@@ -147,11 +147,11 @@ export default class EHRService{
                 decrypted = await this.decrypt(encrypted, tag, iv);
                 if(file.name == "prescriptions.json"){
                     // Parse
-                    prescriptions = prescriptions.concat(await this.parseIntoArray(decrypted));
+                    prescriptions = prescriptions.concat(await this.parseIntoJSON(decrypted));
                 }
                 else if(file.name == "diagnoses.json"){
                     // Parse
-                    diagnoses = diagnoses.concat(await this.parseIntoArray(decrypted));
+                    diagnoses = diagnoses.concat(await this.parseIntoJSON(decrypted));
                 }
                 else{
                     finalFiles.push(file)
@@ -253,43 +253,30 @@ export default class EHRService{
             decrypted = await this.decrypt(encrypted, tag, iv);
             if(file.name == "prescriptions.json"){
                 // Parse
-                EHR.prescriptions = EHR.prescriptions.concat(await this.parseIntoArray(decrypted));
+                EHR.prescriptions = EHR.prescriptions.concat(await this.parseIntoJSON(decrypted));
             }
             else if(file.name == "diagnoses.json"){
                 // Parse
-                EHR.diagnoses = EHR.diagnoses.concat(await this.parseIntoArray(decrypted));
+                EHR.diagnoses = EHR.diagnoses.concat(await this.parseIntoJSON(decrypted));
             }
             else{
                 // Parse
-                EHR.journals = EHR.journals.concat(await this.parseIntoArray(decrypted));
+                EHR.journals = EHR.journals.concat(await this.parseIntoJSON(decrypted));
             }
         }
         return EHR;
     }
 
     /**
-     * Parses JSON-string to an array of strings
+     * Parser 
      * @param  {Array<string>} input
-     * @returns  {Promise<Array<string>>}
+     * @returns  {Promise<Array<string> | object>}
      * @author Christopher Molin
      */
-    static async parseIntoArray(input){
+    static async parseIntoJSON(input){
 
         let array = await JSON.parse(input);
         return array;
-    }
-
-    /**
-     * Parses JSON-string into JSON
-     * @param  {Array<string>} input
-     * @returns  {Promise<object>}
-     * @author Christopher Molin
-     */
-     static async parseIntoEHR(input){
-
-        let ehr = await JSON.parse(input);
-        console.log(ehr)
-        return ehr;
     }
 
     /**
@@ -322,15 +309,7 @@ export default class EHRService{
      * @returns {Promise<string>}
      */
     static async decrypt(content, tag, iv){
-        
-        /*
-        console.log("before encryptRecordKey")
-        let x = crypt.decryptRecordKey(PlaceholderValues.recordKey,PlaceholderValues.privateKey)
-        console.log(x)
-        return "no :)";
-        */
 
-        let privateKey = PlaceholderValues.medicPrivateKey;
         let ivBuffer = Buffer.from(iv, "base64");
         let tagBuffer = Buffer.from(tag,"base64");
 
@@ -342,8 +321,6 @@ export default class EHRService{
         console.log(ivBuffer.toString("base64"))
         console.log("TAG:")
         console.log(tagBuffer.toString("base64"))
-        
-
 
         let EHR = {
             iv: ivBuffer,
@@ -356,7 +333,7 @@ export default class EHRService{
         let x = crypt.decryptEHR(
             PlaceholderValues.recordKey,
             EHR,
-            privateKey)
+            PlaceholderValues.medicPrivateKey)
 
         console.log("DECRYPTED DATA:")
         console.log(x)

--- a/client/src/Helpers/ehrService.js
+++ b/client/src/Helpers/ehrService.js
@@ -233,8 +233,8 @@ export default class EHRService{
 
         let fs = new FileService(apiToken);
 
-        let fetchedFiles = await fs.fetchEHRFiles(cid);
-        
+        let fetchedFiles = (await fs.fetchEHRFiles(cid)).files;
+        console.log("fetch success")
         let EHR = {
             prescriptions: [],
             diagnoses: [],

--- a/client/src/Helpers/ehrService.js
+++ b/client/src/Helpers/ehrService.js
@@ -121,9 +121,9 @@ export default class EHRService{
 
             // FETCH OLD FILES
             let oldCID = PlaceholderValues.ipfsCID;
-            console.log("testb4")
+            console.log("Attempting Fetch")
             let fetchedFiles = await fs.fetchEHRFiles(oldCID);
-            console.log("test")
+            console.log("Fetch success, found "+fetchedFiles.length+" files!")
 
             let oldFiles = [];
 
@@ -132,7 +132,7 @@ export default class EHRService{
             
             for (const file of fetchedFiles){
                 let decrypted;
-                console.log(file.name+"before:"+await file.text())
+                console.log("Fetched: "+file.name)
                 if(file.name == "prescriptions.json"){
                     // Decrypt
                     
@@ -152,7 +152,7 @@ export default class EHRService{
                     decrypted = await this.decrypt(await file.text(), PlaceholderValues.tagEHR, PlaceholderValues.ivEHR);
                     //finalFiles.push(file)
                 }
-                console.log("after:"+decrypted)
+                //console.log("after:"+decrypted)
             }
             
 

--- a/client/src/Helpers/ehrService.js
+++ b/client/src/Helpers/ehrService.js
@@ -139,13 +139,13 @@ export default class EHRService{
                     decrypted = await this.decrypt(await file.text(),PlaceholderValues.tagPrescriptions, PlaceholderValues.ivPrescriptions);
                     
                     // Parse
-                    prescriptions = prescriptions.concat(await this.parseIntoArray(decrypted));
+                    //prescriptions = prescriptions.concat(await this.parseIntoArray(decrypted));
                 }
                 else if(file.name == "diagnoses.json"){
                     // Decrypt
                     decrypted = await this.decrypt(await file.text(), PlaceholderValues.tagDiagnoses, PlaceholderValues.ivDiagnoses);
                     // Parse
-                    diagnoses = diagnoses.concat(await this.parseIntoArray(decrypted));
+                    //diagnoses = diagnoses.concat(await this.parseIntoArray(decrypted));
                 }
                 else{
                     // For uploading

--- a/client/src/Helpers/ehrService.js
+++ b/client/src/Helpers/ehrService.js
@@ -6,6 +6,7 @@ import FileService from "./fileService";
 import { database, ref, get, child } from "../../firebaseSetup";
 import FetchFileContentError from "./Errors/FetchFileContentError";
 import { PlaceholderValues } from "../placeholders/placeholderValues";
+import { encryptEHR } from "../../Crypto/crypt";
 
 
 
@@ -285,7 +286,7 @@ export default class EHRService{
      * @returns {Promise<string>}
      */
     static async encrypt(content){
-        return content;
+        return encryptEHR(PlaceholderValues.recordKey,content,PlaceholderValues.medicPrivateKey);
     }
     /**
      * PLACEHOLDER

--- a/client/src/Helpers/fileService.js
+++ b/client/src/Helpers/fileService.js
@@ -81,7 +81,7 @@ export default class FileService{
     /**
      * Fetches all EHR files
      * @param  {String} cid
-     * @returns {Promise<*>} results -- Array with all File objects in CID-directory
+     * @returns {Promise<{files: Array<File>, index: number}>} results -- Array with all File objects in CID-directory
      * @author @Chrimle
      */
     async fetchEHRFiles(cid){

--- a/client/src/Helpers/fileService.js
+++ b/client/src/Helpers/fileService.js
@@ -88,8 +88,6 @@ export default class FileService{
 
         let results = [];
 
-        //let fileNames = await this.retrieveFileNames(cid);
-
         // Get prescriptions
         let content = await FileService.fetchFileContent(cid, "prescriptions.json");
         let file = new File([content], "prescriptions.json", { type: 'text/json' });

--- a/client/src/Helpers/fileService.js
+++ b/client/src/Helpers/fileService.js
@@ -10,7 +10,7 @@ export default class FileService{
     /**
      * Constructs a FileService object with the API Token to Web3Storage
      * @param  {String} apiToken
-     * @author @Chrimle
+     * @author Christopher Molin
      */
     constructor(apiToken){
         this.client = new Web3Storage({ token: apiToken});
@@ -21,9 +21,9 @@ export default class FileService{
      * Creates a JSON-file with the content and name specified
      * @param  {String} content
      * @param  {String} fileName
-     * @returns {Promise<File>} -- file object with the name and content provided
+     * @returns {Promise<File>} file object with the name and content provided
      * @throws {CreateFileObjectError}
-     * @author @Chrimle
+     * @author Christopher Molin
      */
     static async createJSONFile( content, fileName ){
         try{
@@ -38,10 +38,10 @@ export default class FileService{
     
     /**
      * Uploads file(s) to Web3Storage and returns the CID for the root folder
-     * @param  {Array<File>} files
-     * @returns {Promise<String>} cid -- The Web3Storage CID to the root folder
+     * @param  {Array<File>} files The files to be uploaded
+     * @returns {Promise<String>} The IPFS CID to the root folder
      * @throws {UploadFileError}
-     * @author @Chrimle
+     * @author Christopher Molin
      */
      async uploadFiles(files){
 
@@ -57,11 +57,11 @@ export default class FileService{
 
     /**
      * Fetches a Web3Storage file, and returns fhe content
-     * @param  {String} cid -- Only the random part of the full address
-     * @param  {String} fileName -- The name and filetype of the file
+     * @param  {String} cid Only the random part of the full address
+     * @param  {String} fileName The name and filetype of the file
      * @returns {Promise<string>} content 
-     * @author @Chrimle
-     * Inspiration: Kamil Kiełczewski https://stackoverflow.com/a/55784549/5424535
+     * @author Christopher Molin 
+     * - Inspiration: Kamil Kiełczewski https://stackoverflow.com/a/55784549/5424535
      */
     static async fetchFileContent(cid, fileName){
 
@@ -81,10 +81,11 @@ export default class FileService{
     /**
      * Fetches all EHR files
      * @param  {String} cid
-     * @returns {Promise<{files: Array<File>, index: number}>} results -- Array with all File objects in CID-directory
-     * @author @Chrimle
+     * @param {boolean} [getNextEHRIndex]
+     * @returns {Promise<{files: Array<File>, index?: number}>} Array with Files and the next index for EHR if upload is true
+     * @author Christopher Molin
      */
-    async fetchEHRFiles(cid){
+    async fetchEHRFiles(cid, getNextEHRIndex){
 
         let results = [];
 
@@ -92,13 +93,12 @@ export default class FileService{
         let content = await FileService.fetchFileContent(cid, "prescriptions.json");
         let file = new File([content], "prescriptions.json", { type: 'text/json' });
         results.push(file);
-        console.log("Got pre:"+content)
 
         // get diagnoses
         content = await FileService.fetchFileContent(cid, "diagnoses.json");
         file = new File([content], "diagnoses.json", { type: 'text/json' });
         results.push(file);
-        console.log("Got dia:"+content)
+
         // LOOP: get EHR_index
         let index = 0;
         let keepSearching = true;
@@ -106,7 +106,7 @@ export default class FileService{
             try{
                 let fileName = "EHR_"+index+".json"
                 let content = await FileService.fetchFileContent(cid, fileName);
-                console.log("Got EHR:"+content)
+
                 if (content.search("ipfs resolve") == -1){
                     let file = new File([content], fileName, { type: 'text/json' });
                     results.push(file);  
@@ -120,7 +120,13 @@ export default class FileService{
             }
         } while(keepSearching)
 
-        return {files: results, index: index};
+        if (getNextEHRIndex){
+            return {files: results, index: index};
+        }
+        else{
+            return {files: results};
+        }
+        
     }
 
 

--- a/client/src/Helpers/fileService.js
+++ b/client/src/Helpers/fileService.js
@@ -21,11 +21,11 @@ export default class FileService{
      * Creates a JSON-file with the content and name specified
      * @param  {String} content
      * @param  {String} fileName
-     * @returns {File} -- file object with the name and content provided
+     * @returns {Promise<File>} -- file object with the name and content provided
      * @throws {CreateFileObjectError}
      * @author @Chrimle
      */
-    static createJSONFile( content, fileName ){
+    static async createJSONFile( content, fileName ){
         try{
             return new File([content], fileName+'.json', { type: 'text/json' });
         }

--- a/client/src/placeholders/placeholderValues.js
+++ b/client/src/placeholders/placeholderValues.js
@@ -7,13 +7,13 @@ export class PlaceholderValues{
   static ipfsCID = "bafybeic2n6soaty4gjmhsnw2rywrxf2h6xdde4iupmlt5s5j7m67pvnfwa"
 
   static tagEHR= "jnMCY+0ZKlHJdiAosx8lYQ==";
-  static ivEHR = "LY9Mrp3+GUagOweft09KM6CCkcs7FOxmuBtIs3jivP4="
+  static ivEHR = "LY9Mrp3+GUagOweft09KM6CCkcs7FOxmuBtIs3jivP4=";
 
   static tagPrescriptions = "ESJunxZldPBEV42HyZ8AgA==";
-  static ivPrescriptions = "RyAzlXYE9IL2Mv0QifOmZDxezTd7i7cXP/pqpX+61Ps="
+  static ivPrescriptions = "RyAzlXYE9IL2Mv0QifOmZDxezTd7i7cXP/pqpX+61Ps=";
 
   static tagDiagnoses = "ZEemAXGR33z/qEnbuEcHjA==";
-  static ivDiagnoses = "N1lnPOao8AKuHgLPfb0dUql2eVOc/15HCQyULxmzeww="
+  static ivDiagnoses = "N1lnPOao8AKuHgLPfb0dUql2eVOc/15HCQyULxmzeww=";
   
 
   static privateKey = `-----BEGIN PRIVATE KEY-----

--- a/client/src/placeholders/placeholderValues.js
+++ b/client/src/placeholders/placeholderValues.js
@@ -4,7 +4,7 @@ export class PlaceholderValues{
 
 
   
-  static ipfsCID = "bafybeighyjh33wrv6xxdgsowiopp3yykiez74ps3uuvouwt5pugi4kcm6a"
+  static ipfsCID = "bafybeihcjr6rbsjgfljtrl5ii2duyrotmv2l527ufz6aao32rx7fp2k7ya"
   
   static tagEHR           = "v0F4M64Xcw+HHJo5Xow70Q==";
   static ivEHR =  "szZVrAUdUMo1XEdmGU0jOshALYYJ1bZGl8YpX4WYtKw=";

--- a/client/src/placeholders/placeholderValues.js
+++ b/client/src/placeholders/placeholderValues.js
@@ -1,4 +1,59 @@
-export class PlaceholderValues{    
+export class PlaceholderValues{
+
+  static privateKey = `-----BEGIN PRIVATE KEY-----
+MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBANSIBpLQNO+J+VGL
+TO6bhB+lO6lOoRwCe6NPcjqv1r0z6Eu3eEFfvkgGpCxxwZjpj8Vb/OfCgJkABNn4
+ecBS4j0iYhIz0BS4624Z+G/6kFcy/MqUeUOPSUeJMOWdCH8usjXqkTuB9bT0WOiN
+mPNm2x5oOPUceK/MP4QW/YtzJa1TAgMBAAECgYAtvPhtMBG0W2Ukf24XC7DrfovQ
+a/OQK5igFMDokF8OaNVdNibTKt+wcH10cybO2bTvLFTJK7qxMqfYoPjSwwOc8Bpb
+YzRsXgpanydspsUOvoCNXtHmEybSmZ1meP1URB2WD/Lt1fHl5x4PXfbetoqK+Da4
+m1GNnMbDI9gIwUdtQQJBAOuA3V+1LfYNOPPRQI9vQmzSZapty+KsCQADqZEl3JR7
+7xDUzucLv0owfJMaotISN65c+mTdkM3sdbeY47kO4PUCQQDnB1Ub1z4hkPIJOEAm
+ak+EsKPyC2DuKK8QOB+ddX1CCaienmgWfWuN6nImO5Rwmv0JsUYK6mMgOTX3gzXc
+WsgnAkB+yKdlKRMPTdsFV/fbwFgQYcydzfJfm6JUwaP+IlX4EiiH9SlWNXrMJAJM
+56AUW/5h/mhG+QlF8zEEoGiobhwpAkBFDe8FjFe45r9BvDuIf/xWuAm4/mexqB1z
+pqLkiMqw43wwNT79ge2VFL+b5/Edm2YI8KD0AE0yw4b6/ZAq1kO/AkAWUBHUxI1K
+bIq/ZkmEM0nbWOu8uU60hoos0oHKjuBF9KFN8p3dlodz0N02UAqLjjx1COiC341F
+HTPhtf3w2f2F
+-----END PRIVATE KEY-----
+`;
+
+static medicPrivateKey = `-----BEGIN PRIVATE KEY-----
+MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBANSIBpLQNO+J+VGL
+TO6bhB+lO6lOoRwCe6NPcjqv1r0z6Eu3eEFfvkgGpCxxwZjpj8Vb/OfCgJkABNn4
+ecBS4j0iYhIz0BS4624Z+G/6kFcy/MqUeUOPSUeJMOWdCH8usjXqkTuB9bT0WOiN
+mPNm2x5oOPUceK/MP4QW/YtzJa1TAgMBAAECgYAtvPhtMBG0W2Ukf24XC7DrfovQ
+a/OQK5igFMDokF8OaNVdNibTKt+wcH10cybO2bTvLFTJK7qxMqfYoPjSwwOc8Bpb
+YzRsXgpanydspsUOvoCNXtHmEybSmZ1meP1URB2WD/Lt1fHl5x4PXfbetoqK+Da4
+m1GNnMbDI9gIwUdtQQJBAOuA3V+1LfYNOPPRQI9vQmzSZapty+KsCQADqZEl3JR7
+7xDUzucLv0owfJMaotISN65c+mTdkM3sdbeY47kO4PUCQQDnB1Ub1z4hkPIJOEAm
+ak+EsKPyC2DuKK8QOB+ddX1CCaienmgWfWuN6nImO5Rwmv0JsUYK6mMgOTX3gzXc
+WsgnAkB+yKdlKRMPTdsFV/fbwFgQYcydzfJfm6JUwaP+IlX4EiiH9SlWNXrMJAJM
+56AUW/5h/mhG+QlF8zEEoGiobhwpAkBFDe8FjFe45r9BvDuIf/xWuAm4/mexqB1z
+pqLkiMqw43wwNT79ge2VFL+b5/Edm2YI8KD0AE0yw4b6/ZAq1kO/AkAWUBHUxI1K
+bIq/ZkmEM0nbWOu8uU60hoos0oHKjuBF9KFN8p3dlodz0N02UAqLjjx1COiC341F
+HTPhtf3w2f2F
+-----END PRIVATE KEY-----
+`;
+
+static recordKey = `-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDUiAaS0DTviflRi0zum4QfpTup
+TqEcAnujT3I6r9a9M+hLt3hBX75IBqQsccGY6Y/FW/znwoCZAATZ+HnAUuI9ImIS
+M9AUuOtuGfhv+pBXMvzKlHlDj0lHiTDlnQh/LrI16pE7gfW09FjojZjzZtseaDj1
+HHivzD+EFv2LcyWtUwIDAQAB
+-----END PUBLIC KEY-----
+`;
+
+  static publicKey = `-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDUiAaS0DTviflRi0zum4QfpTup
+TqEcAnujT3I6r9a9M+hLt3hBX75IBqQsccGY6Y/FW/znwoCZAATZ+HnAUuI9ImIS
+M9AUuOtuGfhv+pBXMvzKlHlDj0lHiTDlnQh/LrI16pE7gfW09FjojZjzZtseaDj1
+HHivzD+EFv2LcyWtUwIDAQAB
+-----END PUBLIC KEY-----
+`;
+
+
+
     static allRegions = ["Stockholm","Uppsala","Sormland","Ostergotland","Jonkoping","Kronoberg","Kalmar","Gotland","Blekinge","Skane","Halland","Varmland","Orebro","Vastmanland","Dalarna","Gavleborg","Vasternorrland","Jamtland","Vasterbotten","Norrbotten","Vastra Gotaland"];
     static permittedRegions = ["Västra Götaland","Skåne"];
     static diagnoses = ["Birch Allergy"];

--- a/client/src/placeholders/placeholderValues.js
+++ b/client/src/placeholders/placeholderValues.js
@@ -4,16 +4,16 @@ export class PlaceholderValues{
 
 
   
-  static ipfsCID = "bafybeic2n6soaty4gjmhsnw2rywrxf2h6xdde4iupmlt5s5j7m67pvnfwa"
+  static ipfsCID = "bafybeib2w4dqgqzf57utwznbla3wt4sn7ounxkblehgrt4ov5uiboj66pq"
+  
+  static tagEHR           = "v0F4M64Xcw+HHJo5Xow70Q==";
+  static ivEHR =  "szZVrAUdUMo1XEdmGU0jOshALYYJ1bZGl8YpX4WYtKw=";
+                  "1dTkXS9xQBQxgqoMtmenEQ7vbFxnGTvhEIiyp9qr0c8d"
+  static tagPrescriptions = "mcU8ffB8ZybbUHNiPBAUKA==";
+  static ivPrescriptions = "Y5LA1ThHV6hsPGxWWR6VfGjwzJXxWLHWY88NgHX2Dx4=";
 
-  static tagEHR= "jnMCY+0ZKlHJdiAosx8lYQ==";
-  static ivEHR = "LY9Mrp3+GUagOweft09KM6CCkcs7FOxmuBtIs3jivP4=";
-
-  static tagPrescriptions = "ESJunxZldPBEV42HyZ8AgA==";
-  static ivPrescriptions = "RyAzlXYE9IL2Mv0QifOmZDxezTd7i7cXP/pqpX+61Ps=";
-
-  static tagDiagnoses = "ZEemAXGR33z/qEnbuEcHjA==";
-  static ivDiagnoses = "N1lnPOao8AKuHgLPfb0dUql2eVOc/15HCQyULxmzeww=";
+  static tagDiagnoses = "oso6cFFJxmT55WjbOzozag==";
+  static ivDiagnoses = "GFvkkz2Fkc9fi2RrpIi/jVMVath+MAvTjVUTipqqfHE=";
   
 
   static privateKey = `-----BEGIN PRIVATE KEY-----

--- a/client/src/placeholders/placeholderValues.js
+++ b/client/src/placeholders/placeholderValues.js
@@ -1,19 +1,7 @@
 
 export class PlaceholderValues{
 
-
-
-  
   static ipfsCID = "bafybeihcjr6rbsjgfljtrl5ii2duyrotmv2l527ufz6aao32rx7fp2k7ya"
-  
-  static tagEHR           = "v0F4M64Xcw+HHJo5Xow70Q==";
-  static ivEHR =  "szZVrAUdUMo1XEdmGU0jOshALYYJ1bZGl8YpX4WYtKw=";
-                  "1dTkXS9xQBQxgqoMtmenEQ7vbFxnGTvhEIiyp9qr0c8d"
-  static tagPrescriptions = "mcU8ffB8ZybbUHNiPBAUKA==";
-  static ivPrescriptions = "Y5LA1ThHV6hsPGxWWR6VfGjwzJXxWLHWY88NgHX2Dx4=";
-
-  static tagDiagnoses = "oso6cFFJxmT55WjbOzozag==";
-  static ivDiagnoses = "GFvkkz2Fkc9fi2RrpIi/jVMVath+MAvTjVUTipqqfHE=";
   
 
   static privateKey = `-----BEGIN PRIVATE KEY-----

--- a/client/src/placeholders/placeholderValues.js
+++ b/client/src/placeholders/placeholderValues.js
@@ -3,13 +3,17 @@ export class PlaceholderValues{
 
 
 
-  static tag = Buffer.from([0x9e, 0x1b, 0x72, 0xbc, 0x70, 0xc3, 0xbd, 0xde, 0x73, 0xcd, 0x7c, 0x64, 0x51, 0x1b, 0xc5, 0xae])
-  static iv = "X1CaFR0Dj+vUG8lWVs5Kt2l7RzDD4dq8Pv/MUen6WIM=";
+  
+  static ipfsCID = "bafybeic2n6soaty4gjmhsnw2rywrxf2h6xdde4iupmlt5s5j7m67pvnfwa"
 
-  static tagPrescriptions = "JqlkGRmVC/PIbrRWK7/woA==";
-  static tagDiagnoses = "VvEniXEOaRURsAIOavhYPQ==";
-  static tagEHR= "Y1y0e+vHxF7T2pSPTgLGwg==";
+  static tagEHR= "jnMCY+0ZKlHJdiAosx8lYQ==";
+  static ivEHR = "LY9Mrp3+GUagOweft09KM6CCkcs7FOxmuBtIs3jivP4="
 
+  static tagPrescriptions = "ESJunxZldPBEV42HyZ8AgA==";
+  static ivPrescriptions = "RyAzlXYE9IL2Mv0QifOmZDxezTd7i7cXP/pqpX+61Ps="
+
+  static tagDiagnoses = "ZEemAXGR33z/qEnbuEcHjA==";
+  static ivDiagnoses = "N1lnPOao8AKuHgLPfb0dUql2eVOc/15HCQyULxmzeww="
   
 
   static privateKey = `-----BEGIN PRIVATE KEY-----
@@ -48,7 +52,7 @@ HTPhtf3w2f2F
 -----END PRIVATE KEY-----
 `;
 
-static encryptedRecordKey = "LhUjB3jms1JNWgHfmsNZcjrAgQWdRzITn49lZs+CHfSkWTWkqNNKY9/Qn/GdJh1jE1fmSOfnuRgE2BuwUl3TG25TDYIGqmFVG3ydSOyi5i5PqE5xWJSOTvn4g6zp/syPzzA8pr8zD//f8d2+C97Nvpypfh8DaUhG2HY2FyaHyIE=";
+static recordKey = "LhUjB3jms1JNWgHfmsNZcjrAgQWdRzITn49lZs+CHfSkWTWkqNNKY9/Qn/GdJh1jE1fmSOfnuRgE2BuwUl3TG25TDYIGqmFVG3ydSOyi5i5PqE5xWJSOTvn4g6zp/syPzzA8pr8zD//f8d2+C97Nvpypfh8DaUhG2HY2FyaHyIE=";
 
   static publicKey = `-----BEGIN PUBLIC KEY-----
 MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDUiAaS0DTviflRi0zum4QfpTup

--- a/client/src/placeholders/placeholderValues.js
+++ b/client/src/placeholders/placeholderValues.js
@@ -1,9 +1,16 @@
+
 export class PlaceholderValues{
 
 
 
   static tag = Buffer.from([0x9e, 0x1b, 0x72, 0xbc, 0x70, 0xc3, 0xbd, 0xde, 0x73, 0xcd, 0x7c, 0x64, 0x51, 0x1b, 0xc5, 0xae])
   static iv = "X1CaFR0Dj+vUG8lWVs5Kt2l7RzDD4dq8Pv/MUen6WIM=";
+
+  static tagPrescriptions = "JqlkGRmVC/PIbrRWK7/woA==";
+  static tagDiagnoses = "VvEniXEOaRURsAIOavhYPQ==";
+  static tagEHR= "Y1y0e+vHxF7T2pSPTgLGwg==";
+
+  
 
   static privateKey = `-----BEGIN PRIVATE KEY-----
 MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBANSIBpLQNO+J+VGL
@@ -41,7 +48,7 @@ HTPhtf3w2f2F
 -----END PRIVATE KEY-----
 `;
 
-static encryptedRecordKey = `LhUjB3jms1JNWgHfmsNZcjrAgQWdRzITn49lZs+CHfSkWTWkqNNKY9/Qn/GdJh1jE1fmSOfnuRgE2BuwUl3TG25TDYIGqmFVG3ydSOyi5i5PqE5xWJSOTvn4g6zp/syPzzA8pr8zD//f8d2+C97Nvpypfh8DaUhG2HY2FyaHyIE=`;
+static encryptedRecordKey = "LhUjB3jms1JNWgHfmsNZcjrAgQWdRzITn49lZs+CHfSkWTWkqNNKY9/Qn/GdJh1jE1fmSOfnuRgE2BuwUl3TG25TDYIGqmFVG3ydSOyi5i5PqE5xWJSOTvn4g6zp/syPzzA8pr8zD//f8d2+C97Nvpypfh8DaUhG2HY2FyaHyIE=";
 
   static publicKey = `-----BEGIN PUBLIC KEY-----
 MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDUiAaS0DTviflRi0zum4QfpTup

--- a/client/src/placeholders/placeholderValues.js
+++ b/client/src/placeholders/placeholderValues.js
@@ -1,5 +1,10 @@
 export class PlaceholderValues{
 
+
+
+  static tag = Buffer.from([0x9e, 0x1b, 0x72, 0xbc, 0x70, 0xc3, 0xbd, 0xde, 0x73, 0xcd, 0x7c, 0x64, 0x51, 0x1b, 0xc5, 0xae])
+  static iv = "X1CaFR0Dj+vUG8lWVs5Kt2l7RzDD4dq8Pv/MUen6WIM=";
+
   static privateKey = `-----BEGIN PRIVATE KEY-----
 MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBANSIBpLQNO+J+VGL
 TO6bhB+lO6lOoRwCe6NPcjqv1r0z6Eu3eEFfvkgGpCxxwZjpj8Vb/OfCgJkABNn4
@@ -36,13 +41,7 @@ HTPhtf3w2f2F
 -----END PRIVATE KEY-----
 `;
 
-static recordKey = `-----BEGIN PUBLIC KEY-----
-MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDUiAaS0DTviflRi0zum4QfpTup
-TqEcAnujT3I6r9a9M+hLt3hBX75IBqQsccGY6Y/FW/znwoCZAATZ+HnAUuI9ImIS
-M9AUuOtuGfhv+pBXMvzKlHlDj0lHiTDlnQh/LrI16pE7gfW09FjojZjzZtseaDj1
-HHivzD+EFv2LcyWtUwIDAQAB
------END PUBLIC KEY-----
-`;
+static encryptedRecordKey = `LhUjB3jms1JNWgHfmsNZcjrAgQWdRzITn49lZs+CHfSkWTWkqNNKY9/Qn/GdJh1jE1fmSOfnuRgE2BuwUl3TG25TDYIGqmFVG3ydSOyi5i5PqE5xWJSOTvn4g6zp/syPzzA8pr8zD//f8d2+C97Nvpypfh8DaUhG2HY2FyaHyIE=`;
 
   static publicKey = `-----BEGIN PUBLIC KEY-----
 MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDUiAaS0DTviflRi0zum4QfpTup

--- a/client/src/placeholders/placeholderValues.js
+++ b/client/src/placeholders/placeholderValues.js
@@ -4,7 +4,7 @@ export class PlaceholderValues{
 
 
   
-  static ipfsCID = "bafybeib2w4dqgqzf57utwznbla3wt4sn7ounxkblehgrt4ov5uiboj66pq"
+  static ipfsCID = "bafybeighyjh33wrv6xxdgsowiopp3yykiez74ps3uuvouwt5pugi4kcm6a"
   
   static tagEHR           = "v0F4M64Xcw+HHJo5Xow70Q==";
   static ivEHR =  "szZVrAUdUMo1XEdmGU0jOshALYYJ1bZGl8YpX4WYtKw=";

--- a/client/src/screens/Overview/EHROverviewScreen.js
+++ b/client/src/screens/Overview/EHROverviewScreen.js
@@ -74,11 +74,11 @@ export function EHROverviewScreen(props) {
           const allRegions = await EHRService.getRegions();
           const patientPermittedRegions = await EHRService.getPatientRegions((state.doctorRole ? props.route.params : userSSN ))
 
-          let ehr = await EHRService.getEHR((state.doctorRole ? props.route.params : userSSN ))
+          //let ehr = await EHRService.getEHR((state.doctorRole ? props.route.params : userSSN ))
 
-          const patientPrescriptions = ehr.prescriptions
-          const patientDiagnoses = ehr.diagnoses;
-          const patientJournals = ehr.journals;
+          const patientPrescriptions = []//ehr.prescriptions
+          const patientDiagnoses = []//ehr.diagnoses;
+          const patientJournals = []//ehr.journals;
 
           let journalIndexes = [];
           patientJournals.forEach(() => journalIndexes.push(false));

--- a/client/src/screens/Overview/EHROverviewScreen.js
+++ b/client/src/screens/Overview/EHROverviewScreen.js
@@ -74,11 +74,11 @@ export function EHROverviewScreen(props) {
           const allRegions = await EHRService.getRegions();
           const patientPermittedRegions = await EHRService.getPatientRegions((state.doctorRole ? props.route.params : userSSN ))
 
-          //let ehr = await EHRService.getEHR((state.doctorRole ? props.route.params : userSSN ))
+          let ehr = await EHRService.getEHR((state.doctorRole ? props.route.params : userSSN ))
 
-          const patientPrescriptions = []//ehr.prescriptions
-          const patientDiagnoses = []//ehr.diagnoses;
-          const patientJournals = []//ehr.journals;
+          const patientPrescriptions = ehr.prescriptions
+          const patientDiagnoses = ehr.diagnoses;
+          const patientJournals = ehr.journals;
 
           let journalIndexes = [];
           patientJournals.forEach(() => journalIndexes.push(false));

--- a/test/testCrypto.js
+++ b/test/testCrypto.js
@@ -42,6 +42,7 @@ describe("Test crypto", function () {
     // check if a publicKey can be derived from a privateKey
     assert.doesNotThrow(() => {
       publicKey = crypt.extractPublicKeyFromPrivateKey(privateKey);
+      console.log(publicKey.);
     });
   });
 

--- a/test/testCrypto.js
+++ b/test/testCrypto.js
@@ -42,7 +42,7 @@ describe("Test crypto", function () {
     // check if a publicKey can be derived from a privateKey
     assert.doesNotThrow(() => {
       publicKey = crypt.extractPublicKeyFromPrivateKey(privateKey);
-      console.log(publicKey.);
+      console.log(publicKey);
     });
   });
 

--- a/test/testCrypto.js
+++ b/test/testCrypto.js
@@ -12,6 +12,8 @@ import JSONService from "../server/jsonHandling/jsonService.js";
 
 const example_directory = "./test/json_examples";
 var record_key = crypto.KeyObject;
+let privateKey;
+let publicKey;
 
 describe("Test crypto", function () {
   // Generate keys
@@ -34,7 +36,6 @@ describe("Test crypto", function () {
   //Test key derivation function
   it("Can derive publicKey from privateKey", function () {
     //512-bit salt for 512 bit output bitLen
-    const privateKey = fs.readFileSync("./private_key");
     var publicKey;
 
     //console.log("Public key: " + crypt.extractPublicKeyFromPrivateKey(privateKey));
@@ -57,17 +58,14 @@ describe("Test crypto", function () {
 
       // check if record key can be encrypted
       assert.doesNotThrow(() => {
-        encrypted_record_key = crypt.encryptRecordKey(
-          key.export(),
-          "./public_key"
-        );
+        encrypted_record_key = crypt.encryptRecordKey(key.export(), publicKey);
       });
 
       // check if record key can be decrypted
       assert.doesNotThrow(() => {
         decrypted_record_key = crypt.decryptRecordKey(
           encrypted_record_key,
-          "./private_key"
+          privateKey
         );
       });
 
@@ -91,16 +89,12 @@ describe("Test crypto", function () {
     // encrypt the record key
     var encrypted_record_key = crypt.encryptRecordKey(
       record_key.export(),
-      "./public_key"
+      publicKey
     );
 
     // check if EHR can be encrypted
     assert.doesNotThrow(() => {
-      encryptedEHR = crypt.encryptEHR(
-        encrypted_record_key,
-        ehrBuf,
-        "./private_key"
-      );
+      encryptedEHR = crypt.encryptEHR(encrypted_record_key, ehrBuf, privateKey);
     });
 
     // check if EHR can be decrypted
@@ -108,7 +102,7 @@ describe("Test crypto", function () {
       decryptedEHR = crypt.decryptEHR(
         encrypted_record_key,
         encryptedEHR,
-        "./private_key"
+        privateKey
       );
     });
 
@@ -119,6 +113,7 @@ describe("Test crypto", function () {
 
 function generateKeyFiles() {
   // Generate keypair
+
   const keyPair = crypto.generateKeyPairSync("rsa", {
     modulusLength: 1024,
     publicKeyEncoding: {
@@ -132,6 +127,8 @@ function generateKeyFiles() {
   });
 
   // Creating public and private key file
-  fs.writeFileSync("public_key", keyPair.publicKey);
-  fs.writeFileSync("private_key", keyPair.privateKey);
+  //fs.writeFileSync("public_key", keyPair.publicKey);
+  //fs.writeFileSync("private_key", keyPair.privateKey);
+  privateKey = keyPair.privateKey;
+  publicKey = keyPair.publicKey;
 }

--- a/test/testCrypto.js
+++ b/test/testCrypto.js
@@ -129,6 +129,35 @@ function generateKeyFiles() {
   // Creating public and private key file
   //fs.writeFileSync("public_key", keyPair.publicKey);
   //fs.writeFileSync("private_key", keyPair.privateKey);
-  privateKey = keyPair.privateKey;
-  publicKey = keyPair.publicKey;
+  //privateKey = keyPair.privateKey;
+  //publicKey = keyPair.publicKey;
+
+  privateKey = `-----BEGIN PRIVATE KEY-----
+MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBANSIBpLQNO+J+VGL
+TO6bhB+lO6lOoRwCe6NPcjqv1r0z6Eu3eEFfvkgGpCxxwZjpj8Vb/OfCgJkABNn4
+ecBS4j0iYhIz0BS4624Z+G/6kFcy/MqUeUOPSUeJMOWdCH8usjXqkTuB9bT0WOiN
+mPNm2x5oOPUceK/MP4QW/YtzJa1TAgMBAAECgYAtvPhtMBG0W2Ukf24XC7DrfovQ
+a/OQK5igFMDokF8OaNVdNibTKt+wcH10cybO2bTvLFTJK7qxMqfYoPjSwwOc8Bpb
+YzRsXgpanydspsUOvoCNXtHmEybSmZ1meP1URB2WD/Lt1fHl5x4PXfbetoqK+Da4
+m1GNnMbDI9gIwUdtQQJBAOuA3V+1LfYNOPPRQI9vQmzSZapty+KsCQADqZEl3JR7
+7xDUzucLv0owfJMaotISN65c+mTdkM3sdbeY47kO4PUCQQDnB1Ub1z4hkPIJOEAm
+ak+EsKPyC2DuKK8QOB+ddX1CCaienmgWfWuN6nImO5Rwmv0JsUYK6mMgOTX3gzXc
+WsgnAkB+yKdlKRMPTdsFV/fbwFgQYcydzfJfm6JUwaP+IlX4EiiH9SlWNXrMJAJM
+56AUW/5h/mhG+QlF8zEEoGiobhwpAkBFDe8FjFe45r9BvDuIf/xWuAm4/mexqB1z
+pqLkiMqw43wwNT79ge2VFL+b5/Edm2YI8KD0AE0yw4b6/ZAq1kO/AkAWUBHUxI1K
+bIq/ZkmEM0nbWOu8uU60hoos0oHKjuBF9KFN8p3dlodz0N02UAqLjjx1COiC341F
+HTPhtf3w2f2F
+-----END PRIVATE KEY-----
+`;
+
+  publicKey = `-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDUiAaS0DTviflRi0zum4QfpTup
+TqEcAnujT3I6r9a9M+hLt3hBX75IBqQsccGY6Y/FW/znwoCZAATZ+HnAUuI9ImIS
+M9AUuOtuGfhv+pBXMvzKlHlDj0lHiTDlnQh/LrI16pE7gfW09FjojZjzZtseaDj1
+HHivzD+EFv2LcyWtUwIDAQAB
+-----END PUBLIC KEY-----
+`;
+
+  console.log(publicKey)
+  console.log(privateKey)
 }


### PR DESCRIPTION
# It is finally here!

Features:

- EHR-Overview now fetches an encrypted EHR, decrypts it and displays.

- NewEntryScreen now fetches encrypted EHRs, decrypts if needed, and encrypts the new files before upload.

- EHRService can now encrypt, decrypt and parse the files uploaded to/downloaded from Web3Storage

- FileService now circumvents Web3Storage to get the file names of a CID-archive. This also allows more anonymity, as EHRs do not include the timestamp in the name any longer.

- Crypto was heavily adjusted. It now no longer uses any FileSystem. The data is no longer in "Base64". Added correct and useful JSDoc comments.