### PR TITLE
Regions in smart contract

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -17,6 +17,7 @@ function App() {
   const { authentication, user, updateInfo } = apiService();
 
   // set the single chainConnection instance to be used throughout the entire app. 
+  // This is async, so chainConnection will need to be awaited wherever used. 
   const [chainConnection] = React.useState({
     chainConnection: ChainConnectionFactory.getChainConnection(),
   });

--- a/client/src/chainConnection/chainConnection.js
+++ b/client/src/chainConnection/chainConnection.js
@@ -1,6 +1,5 @@
 import Block4EHR from "../../../build/contracts/Block4EHR.json";
 import getWeb3 from "./getWeb3";
-import ChainConnectionError from "./chainConnectionError";
 import ChainOperationDeniedError from "./chainOperationDeniedError";
 
 /**
@@ -15,9 +14,9 @@ import ChainOperationDeniedError from "./chainOperationDeniedError";
 export default class ChainConnection {
   constructor() {
     this.state = {
-      web3: null,
-      accounts: null,
-      contract: null,
+      web3: null, // Web3 instance
+      accounts: null, // Array of ethereum accounts
+      contract: null, // Contract instance
     };
   }
 
@@ -25,6 +24,14 @@ export default class ChainConnection {
     this.state = state;
   }
 
+  /**
+   * Initializes the state variables of the `ChainConnection` instance. 
+   * This method is a slightly modified version of the client/src/App.js file
+   * provided by the truffle box "react". 
+   * @author Hampus Jernkrook
+   * 
+   * TODO: remove the console.log:s when done developing. 
+   */
   async init() {
     console.log("Starting init()");
     try {
@@ -60,7 +67,13 @@ export default class ChainConnection {
     console.log("Done init()");
   }
 
-  // TODO: add error handling if the state is not set correctly
+  /**
+   * Checks it the method invoker has permission to 
+   * access the given patient's EHR.
+   * @param {String} patientId The id of the patient to check permision against. 
+   * @returns {boolean} true iff the invoker is permissioned by the given patient. 
+   * @author Hampus Jernkrook
+   */
   async hasPermission(patientId) {
     const { accounts, contract } = this.state;
     const res = await contract.methods
@@ -69,6 +82,14 @@ export default class ChainConnection {
     return res;
   }
 
+  /**
+   * Get the list of permissioned regions, for the given patient. 
+   * @param {String} patientId The id of the patient to retrieve permissioned regions for. 
+   * @returns {Array<String>} The list of permissioned regions, in the form of region id:s.
+   * @throws {ChainOperationDeniedError} if the operation failed, most likely due to the invoker not
+   *  having permission to invoke it. 
+   * @author Hampus Jernkrook
+   */
   async getPermissionedRegions(patientId) {
     const { accounts, contract } = this.state;
     try {
@@ -81,6 +102,14 @@ export default class ChainConnection {
     }
   }
 
+  /**
+   * Get the CID of the given patient's EHR, stored on the chain. 
+   * @param {String} patientId The id of the patient to retrieve the CID of.
+   * @returns {String} The CID of the given patient's EHR. 
+   * @throws {ChainOperationDeniedError} if the operation failed, most likely due to the invoker not
+   *  having permission to invoke it. 
+   * @author Hampus Jernkrook
+   */
   async getEHRCid(patientId) {
     const { accounts, contract } = this.state;
     try {
@@ -93,6 +122,14 @@ export default class ChainConnection {
     }
   }
 
+  /**
+   * Set the CID of the given patient on the chain. 
+   * @param {String} patientId The id of the patient to set the CID for. 
+   * @param {String} cid The value of CID to be set.
+   * @throws {ChainOperationDeniedError} if the operation failed, most likely due to the invoker not
+   *  having permission to invoke it. 
+   * @author Hampus Jernkrook
+   */
   async updateEHR(patientId, cid) {
     try {
       const { accounts, contract } = this.state;
@@ -104,6 +141,14 @@ export default class ChainConnection {
     }
   }
 
+  /**
+   * Set the list of permissioned regions for the given patient. 
+   * @param {String} patientId The id of the patient to set the list of permissions for. 
+   * @param {Array<String>} regions Array of region id:s that the patient have authorized permission to. 
+   * @throws {ChainOperationDeniedError} if the operation failed, most likely due to the invoker not
+   *  having permission to invoke it. 
+   * @author Hampus Jernkrook 
+   */
   async setPermissions(patientId, regions) {
     try {
       const { accounts, contract } = this.state;

--- a/client/src/chainConnection/chainConnection.js
+++ b/client/src/chainConnection/chainConnection.js
@@ -51,11 +51,19 @@ export default class ChainConnection {
       // Set web3, accounts, and contract to the state.
       this.setState({ web3, accounts, contract: instance });
     } catch (error) {
+      alert(`FATAL: Failed to connect to the blockchain system.\n`+
+        `- If not already connected, please connect your Metamask account.\n`+
+        `- Thereafter, click OK below, and the page will reload and allow you to log in.`
+      );
+      window.location.reload();
+
+      /*
       // Catch any errors for any of the above operations.
       alert(
         `Failed to load web3, accounts, or contract. Check console for details.`
       ); //TODO: change this to something more user friendly and ask user to reload the page and allow metamask to connect. 
       throw new ChainConnectionError(`Failed to load web3, accounts, or contract. Error thrown with message:\n ${error.message}`);
+    */
     }
     console.log("Done init()");
   }

--- a/client/src/chainConnection/chainConnection.js
+++ b/client/src/chainConnection/chainConnection.js
@@ -52,18 +52,10 @@ export default class ChainConnection {
       this.setState({ web3, accounts, contract: instance });
     } catch (error) {
       alert(`FATAL: Failed to connect to the blockchain system.\n`+
-        `- If not already connected, please connect your Metamask account.\n`+
-        `- Thereafter, click OK below, and the page will reload and allow you to log in.`
+        `- If not already connected, you need to allow Metamask to connect to the site.\n` + 
+        `- Click OK below to reload the page. Metamask will prompt you to connect.`
       );
-      window.location.reload();
-
-      /*
-      // Catch any errors for any of the above operations.
-      alert(
-        `Failed to load web3, accounts, or contract. Check console for details.`
-      ); //TODO: change this to something more user friendly and ask user to reload the page and allow metamask to connect. 
-      throw new ChainConnectionError(`Failed to load web3, accounts, or contract. Error thrown with message:\n ${error.message}`);
-    */
+      window.location.reload(); // reload the page. 
     }
     console.log("Done init()");
   }

--- a/client/src/chainConnection/chainConnection.js
+++ b/client/src/chainConnection/chainConnection.js
@@ -1,6 +1,7 @@
 import Block4EHR from "../../../build/contracts/Block4EHR.json";
 import getWeb3 from "./getWeb3";
 import ChainOperationDeniedError from "./chainOperationDeniedError";
+import ChainConnectionError from "./chainConnectionError";
 
 /**
  * Handles the connection to the smart contract Block4EHR on the blockchain. 
@@ -157,6 +158,26 @@ export default class ChainConnection {
           .send({ from: accounts[0] });
     } catch (err) {
       throw new ChainOperationDeniedError(err.message);
+    }
+  }
+
+  /**
+   * Get the list of all regions on the chain.
+   * @returns {Array<Object>} Array of Region objects, with properties `id` and `name`. 
+   * @throws {ChainConnectionError} if the operation failed. In this case, it is most likely
+   *  due to a network error. 
+   * @author Hampus Jernkrook
+   */
+  async getAllRegions() {
+    try {
+      const { accounts, contract } = this.state;
+      const regions = await contract.methods
+        .getRegions()
+        .call({ from: accounts[0] });
+      return regions;
+    } catch (err) {
+      throw new ChainConnectionError(`Could not get regions from the chain.`+
+        `Error thrown with message: ${err.message}`);
     }
   }
 }

--- a/client/src/chainConnection/chainConnectionError.js
+++ b/client/src/chainConnection/chainConnectionError.js
@@ -1,3 +1,7 @@
+/**
+ * Error for use upon blockchain errors arising from network or contract failure.
+ * @author Hampus Jernkrook
+ */
 export default class ChainConnectionError extends Error {
     constructor(msg) {
         super(msg);

--- a/client/src/chainConnection/chainConnectionFactory.js
+++ b/client/src/chainConnection/chainConnectionFactory.js
@@ -11,7 +11,8 @@ export default class ChainConnectionFactory {
      * Initializes a ChainConnection instance and sets all state variables iff
      * no instance has been previously initialized. Else returns the previously
      * initialized instance. 
-     * @returns {ChainConnection} instance with state variables set. 
+     * @returns {Promise<ChainConnection>} instance with state variables set. 
+     * @throws {ChainConnectionError} if the web3 provider, contract or accounts were not loaded correctly. 
      */
     static async getChainConnection() {
         // singleton ChainConnection object. Do not init if already initialized.
@@ -19,7 +20,7 @@ export default class ChainConnectionFactory {
             console.log("Initializing ChainConnection...");
             this._chainConnection = new ChainConnection();
             await this._chainConnection.init();
-            console.log("ChainConnectin Initialized.");
+            console.log("ChainConnection Initialized.");
             return this._chainConnection;
         }
     }

--- a/client/src/chainConnection/chainConnectionFactory.js
+++ b/client/src/chainConnection/chainConnectionFactory.js
@@ -12,7 +12,6 @@ export default class ChainConnectionFactory {
      * no instance has been previously initialized. Else returns the previously
      * initialized instance. 
      * @returns {Promise<ChainConnection>} instance with state variables set. 
-     * @throws {ChainConnectionError} if the web3 provider, contract or accounts were not loaded correctly. 
      */
     static async getChainConnection() {
         // singleton ChainConnection object. Do not init if already initialized.

--- a/client/src/chainConnection/chainOperationDeniedError.js
+++ b/client/src/chainConnection/chainOperationDeniedError.js
@@ -1,3 +1,10 @@
+/**
+ * Error to be used upon operation being reverted on the blockchain. 
+ * Most likely, the invoker of the functin does not have permissions to invoke it,
+ * in that case.
+ * 
+ * @author Hampus Jernkrook
+ */
 export default class ChainOperationDeniedError extends Error {
     constructor(msg) {
         super(`\nOperation reverted.\n` +

--- a/client/src/chainConnection/getWeb3.js
+++ b/client/src/chainConnection/getWeb3.js
@@ -4,7 +4,7 @@
  * Suggested by youtuber EatTheBlocks in https://www.youtube.com/watch?v=LzdMosLzj80
  * for integrating with metamask. 
  * 
- * TODO: remove the console.log:s with CAPSED TEXT
+ * TODO: remove the console.log:s
  * 
  * Copy-pasted and used by @author Hampus Jernkrook
  */

--- a/client/src/screens/Overview/EHROverviewScreen.js
+++ b/client/src/screens/Overview/EHROverviewScreen.js
@@ -224,7 +224,7 @@ export function EHROverviewScreen(props) {
     // ACCOUNT 10: Patient 9801011111 account. 
     // ACCOUNT 2, 3: account of a doctor in region 1 with access to 9801011111. 
     // TESTING hasPermission - set your account to either Account 2, 3 or 10 for this to pass. 
-    const res = await connection.hasPermission("9801011111");
+    // const res = await connection.hasPermission("9801011111");
     // TESTING getPermissionedRegions - set your account to Account 10 for this to pass. 
     // const res = await connection.getPermissionedRegions("9801011111");
     // TESTING getEHRCid - set your account to Account 2 or 3 for this to pass. 
@@ -233,6 +233,8 @@ export function EHROverviewScreen(props) {
     // TESTING setting new permissions - set your account to Account 10 for this to pass. 
     // await connection.setPermissions("9801011111", ["1", "3"]);
     // const res = await connection.getPermissionedRegions("9801011111"); //may have to run this separate from setPermissions
+    // TESTING get all regions - any account can be used for this. 
+    const res = await connection.getAllRegions();
     console.log(res);
     // ================
     console.log("Done discarding.");

--- a/migrations/2_Block4EHR_migration.js
+++ b/migrations/2_Block4EHR_migration.js
@@ -1,28 +1,57 @@
 const Block4EHR = artifacts.require("Block4EHR");
 
 /**
- * Script for deploying the smart contract Block4EHR to the blockchain.
+ * Script for deploying the smart contract Block4EHR 
+ * together with a few initialized objects to the blockchain.
+ * This is hard-coded based on the database elements. 
  * @param {*} deployer
  * @param {*} network
  * @param {*} accounts
  *
  * @author Hampus Jernkrook
+ * 
+ * TODO:
+ * - clean up comments at the end of the file.
+ * - add additional objects if needed. 
  */
 module.exports = function (deployer, network, accounts) {
   deployer.deploy(Block4EHR).then(async () => {
     let instance = await Block4EHR.deployed();
 
+    // ADDING ALL OBJECTS TO HAVE SOME USERS TO TEST AROUND WIT:
+    // We note down which region each object belongs to, to reason about 
+    // who has what access permissions. 
+
+    // ==== ADDING REGIONS ====
+    await instance.addRegion("1", "Stockholm");
+    await instance.addRegion("2", "Uppsala");
+    await instance.addRegion("3", "Sörmland");
+
     // ==== ADDING INSTITUTIONS ====
-    await instance.addHealthcareInst("iy", "g", "gbg");
-    await instance.addHealthcareInst("in", "b", "boras");
+    // FORM: <id, name, region_id>
+    // region 1
+    await instance.addHealthcareInst("2", "Liljeholmskajens vårdcentral", "1");
+    await instance.addHealthcareInst("3", "Segeltorps vårdcentral", "1");
+    // region 2
+    await instance.addHealthcareInst("4", "Gränbystadens vårdcentral", "2");
+    // region 3
+    await instance.addHealthcareInst("5", "Jordbro vårdcentral", "3");
 
     // ==== ADDING MEDICAL PERSONNEL ====
-    await instance.addMedicalPersonnel(accounts[1], "dy", "iy");
-    await instance.addMedicalPersonnel(accounts[2], "dn", "in");
+    // FORM: <account, id, institution_id>
+    // region 1
+    await instance.addMedicalPersonnel(accounts[1], "7403191234", "2"); // works for Liljeholmskajens vårdcentral
+    await instance.addMedicalPersonnel(accounts[2], "8701104455", "3"); // works for Segeltorps vårdcentral
+    // region 2
+    await instance.addMedicalPersonnel(accounts[3], "9711021234", "4"); // works for Gränbystadens vårdcentral
+    // no doctor at institution 5, region 3: jordbro vårdcentral.
 
     // ==== ADDING PATIENTS ====
-    await instance.addPatient(accounts[9], "p_gbg", ["gbg", "kungalv"]);
-    await instance.addPatient(accounts[8], "p_boras", ["boras"]);
+    // FORM: <account, id, permissioned_regions>
+    // region 1
+    await instance.addPatient(accounts[9], "9801011111", ["1"]); // doctors with accounts [1, 2] can access this one's EHR. 
+    // region 2
+    await instance.addPatient(accounts[8], "6503036767", ["2"]); // doctor with accounts [3] can access this one's EHR. 
   });
 };
 
@@ -47,4 +76,26 @@ instance.getPermissionedRegions("p_boras", {from: accounts[8]})
 
 // change account and this will be denied
 instance.setPermissions("p_gbg", [ 'gbg', 'kungalv', 'skovde' ], {from: accounts[9]})
+*/
+/* ILLUSTRATING HOW TO GET THE LIST OF REGIONS FROM THE CHAIN
+AND HOW TO ACCESS THEIR ID AND NAME:
+
+truffle(develop)> let instance = await Block4EHR.deployed();
+undefined
+truffle(develop)> let regions = await instance.getRegions();
+undefined
+truffle(develop)> regions
+[
+  [ '1', 'Stockholm', id: '1', name: 'Stockholm' ],
+  [ '2', 'Uppsala', id: '2', name: 'Uppsala' ],
+  [ '3', 'Sörmland', id: '3', name: 'Sörmland' ]
+]
+truffle(develop)> regions[0]
+[ '1', 'Stockholm', id: '1', name: 'Stockholm' ]
+truffle(develop)> regions[0].id
+'1'
+truffle(develop)> regions[0].name
+'Stockholm'
+truffle(develop)> 
+
 */

--- a/migrations/2_Block4EHR_migration.js
+++ b/migrations/2_Block4EHR_migration.js
@@ -26,6 +26,23 @@ module.exports = function (deployer, network, accounts) {
     await instance.addRegion("1", "Stockholm");
     await instance.addRegion("2", "Uppsala");
     await instance.addRegion("3", "Sörmland");
+    await instance.addRegion("4", "Östergötland");
+    await instance.addRegion("5", "Jönköping");
+    await instance.addRegion("6", "Kalmar");
+    await instance.addRegion("7", "Gotland");
+    await instance.addRegion("8", "Blekinge");
+    await instance.addRegion("9", "Skåne");
+    await instance.addRegion("10", "Halland");
+    await instance.addRegion("11", "Västra Götaland");
+    await instance.addRegion("12", "Värmland");
+    await instance.addRegion("13", "Örebro");
+    await instance.addRegion("14", "Västmanland");
+    await instance.addRegion("15", "Dalarna");
+    await instance.addRegion("16", "Gävleborg");
+    await instance.addRegion("17", "Västernorrland");
+    await instance.addRegion("18", "Jämtland Härjedalen");
+    await instance.addRegion("19", "Västerbotten");
+    await instance.addRegion("20", "Norrbotten");
 
     // ==== ADDING INSTITUTIONS ====
     // FORM: <id, name, region_id>

--- a/truffle_test/test/testBlock4EHR.js
+++ b/truffle_test/test/testBlock4EHR.js
@@ -35,10 +35,15 @@ contract("Block4EHR", accounts => {
     before(async () => {
         instance = await Block4EHR.deployed();
 
+        // ==== ADDING REGIONS ====
+        await instance.addRegion(gbg, "gbg_name");
+        await instance.addRegion(boras, "boras_name");
+        await instance.addRegion(kungalv, "kungalv_name");
+
         // ==== ADDING INSTITUTIONS ====
-        await instance.addHealthcareInst(inst_gbg, "gbg1", "gbg");
-        await instance.addHealthcareInst(inst_boras, "b1", "boras");
-        await instance.addHealthcareInst(inst_kungalv, "k1", "kungalv");
+        await instance.addHealthcareInst(inst_gbg, "gbg1", gbg);
+        await instance.addHealthcareInst(inst_boras, "b1", boras);
+        await instance.addHealthcareInst(inst_kungalv, "k1", kungalv);
 
         // ==== ADDING MEDICAL PERSONNEL ====
         await instance.addMedicalPersonnel(doc_gbg_account, doc_gbg, inst_gbg);


### PR DESCRIPTION
The smart contract now has functionality for storing and retrieving all regions. This is reflected in the migrations script, where all regions are added to the chain (also added some regions to the test file). The tests do not yet test the `getRegions` function however. This needs to be done at a later stage. 
I also added a method for retrieving all regions in `ChainConnection`. 
Also, a lot of added and improved comments. 
And finally, the page now reloads automatically and re-prompts the user to connect metamask, if the user rejects the connection. 