### PR TITLE
Handle EHRs & Permissions

### DIFF
--- a/client/src/Helpers/ehrService.js
+++ b/client/src/Helpers/ehrService.js
@@ -258,6 +258,9 @@ export default class EHRService {
     diagnoses
   ) {
     try {
+
+      let connection = await this.chainConnection;
+
       let apiToken = await EHRService.getWeb3StorageToken();
 
       let fs = new FileService(apiToken);
@@ -296,19 +299,22 @@ export default class EHRService {
       // FETCH OLD FILES
       console.log("Attempting Fetch");
       try{
+        
         let oldCid = await connection.getEHRCid(id);
         let patientEHR = await this.getFiles(oldCid, decryptedRecordKey, true);
 
+        console.debug("get cid & get files")
+        console.table(patientEHR)
         prescriptions = prescriptions.concat(patientEHR.prescriptions);
         diagnoses = diagnoses.concat(patientEHR.diagnoses);
         finalFiles = finalFiles.concat(patientEHR.encryptedEHRFiles);
-
+        index = patientEHR.nextIndex;
       }catch(e){
-
+        console.log(e)
       }
       
       
-      index = patientEHR.nextIndex;
+      
       
 
       // Make into JSON objects
@@ -346,12 +352,12 @@ export default class EHRService {
       finalFiles.push(ehrFile, prescriptionsFile, diagnosesFile);
 
 
-      let connection = await this.chainConnection;
       try{
-        await connection.updateEHR(id, cid);
+        
         // Retrieve CID and return it
         let cid = await fs.uploadFiles(finalFiles);
 
+        await connection.updateEHR(id, cid);
         
         // DEBUG
         let checkCID = await connection.getEHRCid(id);

--- a/client/src/Helpers/ehrService.js
+++ b/client/src/Helpers/ehrService.js
@@ -259,6 +259,9 @@ export default class EHRService {
   ) {
     try {
 
+      id = "".concat(id);
+
+
       let connection = await this.chainConnection;
 
       let apiToken = await EHRService.getWeb3StorageToken();
@@ -462,6 +465,7 @@ export default class EHRService {
    * @author Christopher Molin
    */
   static async getEHR(patientID, role) {
+    patientID = "".concat(patientID);
     // THIS IS ONLY CALLED BY OVERVIEW
 
     let decryptedRecordKey = "";

--- a/client/src/chainConnection/chainConnection.js
+++ b/client/src/chainConnection/chainConnection.js
@@ -78,13 +78,13 @@ export default class ChainConnection {
   async hasPermission(patientId) {
     const { accounts, contract } = this.state;
 
-    let stringID = "".concat(patientId);
+    patientId = "".concat(patientId);
 
     let res = false;
 
     try{
       res = await contract.methods
-      .hasPermission(stringID)
+      .hasPermission(patientId)
       .call({ from: accounts[0] });
     }catch(e){
       // Do something if this fails.
@@ -123,6 +123,7 @@ export default class ChainConnection {
    * @author Hampus Jernkrook
    */
   async getEHRCid(patientId) {
+    patientId = "".concat(patientId);
     const { accounts, contract } = this.state;
     try {
       const cid = await contract.methods
@@ -143,6 +144,7 @@ export default class ChainConnection {
    * @author Hampus Jernkrook
    */
   async updateEHR(patientId, cid) {
+    patientId = "".concat(patientId);
     try {
       const { accounts, contract } = this.state;
       await contract.methods

--- a/client/src/chainConnection/chainConnection.js
+++ b/client/src/chainConnection/chainConnection.js
@@ -77,9 +77,18 @@ export default class ChainConnection {
    */
   async hasPermission(patientId) {
     const { accounts, contract } = this.state;
-    const res = await contract.methods
+
+    let res = false;
+
+    try{
+      res = await contract.methods
       .hasPermission(patientId)
       .call({ from: accounts[0] });
+    }catch(e){
+      // Do something if this fails.
+      console.warn(e);
+    }
+    
     return res;
   }
 

--- a/client/src/chainConnection/chainConnection.js
+++ b/client/src/chainConnection/chainConnection.js
@@ -78,11 +78,13 @@ export default class ChainConnection {
   async hasPermission(patientId) {
     const { accounts, contract } = this.state;
 
+    let stringID = "".concat(patientId);
+
     let res = false;
 
     try{
       res = await contract.methods
-      .hasPermission(patientId)
+      .hasPermission(stringID)
       .call({ from: accounts[0] });
     }catch(e){
       // Do something if this fails.

--- a/client/src/chainConnection/chainConnection.js
+++ b/client/src/chainConnection/chainConnection.js
@@ -78,8 +78,6 @@ export default class ChainConnection {
   async hasPermission(patientId) {
     const { accounts, contract } = this.state;
 
-    patientId = "".concat(patientId);
-
     let res = false;
 
     try{
@@ -123,7 +121,6 @@ export default class ChainConnection {
    * @author Hampus Jernkrook
    */
   async getEHRCid(patientId) {
-    patientId = "".concat(patientId);
     const { accounts, contract } = this.state;
     try {
       const cid = await contract.methods
@@ -144,7 +141,6 @@ export default class ChainConnection {
    * @author Hampus Jernkrook
    */
   async updateEHR(patientId, cid) {
-    patientId = "".concat(patientId);
     try {
       const { accounts, contract } = this.state;
       await contract.methods

--- a/client/src/placeholders/placeholderValues.js
+++ b/client/src/placeholders/placeholderValues.js
@@ -104,6 +104,9 @@ HHivzD+EFv2LcyWtUwIDAQAB
         lastName:"",
         address:"",
         phoneNr:"",
+        journals:[],
+        prescriptions:[],
+        diagnoses:[],
     }
 
 }

--- a/client/src/screens/LoginScreen/LoginScreen.js
+++ b/client/src/screens/LoginScreen/LoginScreen.js
@@ -2,20 +2,18 @@ import React, { useState } from "react";
 import { Text, View, TextInput } from "react-native";
 import { AuthContext } from "../../../contexts/AuthContext";
 import Header from "../../components/Header/Header";
-import { apiService } from "../../../hooks/apiService";
 import Icon from "react-native-vector-icons/Ionicons";
 import Footer from "../../components/Footer";
 import theme from "../../theme.style";
 import ThemeButton from "../../components/themeButton";
 import styles from "./styles";
-import { getAuth } from "@firebase/auth";
+
 
 export function LoginScreen() {
   const { login } = React.useContext(AuthContext);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const auth = getAuth();
-  const userUID = auth.currentUser;
+
 
   const BulletPoint = (props) => {
     const { iconName, labelText, descText } = props;
@@ -30,7 +28,6 @@ export function LoginScreen() {
             {descText}
           </Text>
         </View>
-        
       </View>
     );
   };
@@ -45,7 +42,6 @@ export function LoginScreen() {
 
   return (
     <View style={styles.main}>
-      
       <View style={styles.content}>
         <View style={styles.splitContainer}>
           <View

--- a/client/src/screens/Overview/EHROverviewScreen.js
+++ b/client/src/screens/Overview/EHROverviewScreen.js
@@ -702,6 +702,7 @@ export function EHROverviewScreen(props) {
         <View style={styles.rowContainer}>
           <View style={styles.container}>
             <Text style={styles.header}>Prescriptions</Text>
+            {state.patientInfo.prescriptions.length == 0 && <Text style={styles.description}>No prescriptions found.</Text>}
             <FlatList
               data={state.patientInfo.prescriptions}
               keyExtractor={({ item, index }) => index}
@@ -716,6 +717,7 @@ export function EHROverviewScreen(props) {
           </View>
           <View style={styles.container}>
             <Text style={styles.header}>Diagnoses</Text>
+            {state.patientInfo.diagnoses.length == 0 && <Text style={styles.description}>No diagnoses found.</Text>}
             <FlatList
               data={state.patientInfo.diagnoses}
               keyExtractor={({ item, index }) => index}
@@ -732,6 +734,7 @@ export function EHROverviewScreen(props) {
         <View style={styles.rowContainer}>
           <View style={[styles.container, styles.doubleContainer]}>
             <Text style={styles.header}>Past record entries</Text>
+            {state.patientInfo.prescriptions.length > 0 ?
             <FlatList
               style={{ width: "100%" }}
               data={state.patientInfo.journals}
@@ -848,6 +851,7 @@ export function EHROverviewScreen(props) {
                 </View>
               )}
             />
+            :<Text style={styles.description}>No past journals found.</Text>}
           </View>
         </View>
       </View>

--- a/client/src/screens/StaffScreens/PatientSearchScreen/PatientSearchScreen.js
+++ b/client/src/screens/StaffScreens/PatientSearchScreen/PatientSearchScreen.js
@@ -6,13 +6,16 @@ import ThemeButton from "../../../components/themeButton";
 import styles from "./styles";
 import { useNavigation } from "@react-navigation/native";
 import EHRService from "../../../Helpers/ehrService";
+import { ChainConnectionContext } from "../../../../contexts/ChainConnectionContext";
 
 export function PatientSearchScreen() {
+
+  const { chainConnection } = React.useContext(ChainConnectionContext);
 
   // Change this accordingly
   const expectedPatientIDLength = 10;
   const [patientID, setPatientID] = useState("");
-  const [showError, setShowError] = useState(false);
+  const [showError, setShowError] = useState("");
 
   // Navigation: redirect to the overview (staff version)
   const navigation = useNavigation();
@@ -27,7 +30,7 @@ export function PatientSearchScreen() {
     @Chrimle
   */
   const makeValidPatientID = (e) => {
-    setShowError(false);
+    setShowError("");
     const re = /^[0-9\b]+$/;
       if (e.target.value === "" || re.test(e.target.value)) {
         setPatientID(() => {
@@ -53,11 +56,21 @@ export function PatientSearchScreen() {
           PLACE CODE HERE
           This is where a check for permission COULD be made. 
         */
-        setPatientID("");
-        redirectTo();
+        let connection = await chainConnection;
+
+        if(await connection.hasPermission(patientID)){
+          setPatientID("");
+          setShowError("");
+          redirectTo();
+        }
+        else{
+          setShowError("Error: You lack permission to access "+patientID+"!");
+        }
+
+        
       }
     else{
-      setShowError(true);
+      setShowError("Error: "+patientID+" is not a valid patient ID!");
     }
     
   };
@@ -77,7 +90,7 @@ export function PatientSearchScreen() {
             placeholder="Enter patient ID..."
             placeholderTextColor={"grey"}
           />
-          {showError && <Text style={styles.errorText}>Error: "{patientID}" is not a valid patient ID!</Text>}
+          <Text style={styles.errorText}>{showError}</Text>
           <View style={{width:325, alignSelf:"center", marginTop:5}}>
             <ThemeButton extraStyle={styles.searchButton} iconName="search-sharp" iconSize={50} labelSize={25} labelText="View Patient EHR" bWidth="100%" onPress={() => {searchPatient()}}/>
           </View>

--- a/client/src/screens/StaffScreens/PatientSearchScreen/PatientSearchScreen.js
+++ b/client/src/screens/StaffScreens/PatientSearchScreen/PatientSearchScreen.js
@@ -58,7 +58,9 @@ export function PatientSearchScreen() {
         */
         let connection = await chainConnection;
 
-        if(await connection.hasPermission(patientID)){
+        let patID = "".concat(patientID);
+        
+        if(await connection.hasPermission(patID)){
           setPatientID("");
           setShowError("");
           redirectTo();

--- a/client/src/screens/StaffScreens/PatientSearchScreen/PatientSearchScreen.js
+++ b/client/src/screens/StaffScreens/PatientSearchScreen/PatientSearchScreen.js
@@ -23,39 +23,35 @@ export function PatientSearchScreen() {
     navigation.navigate("EHROverview",patientID);
   };
 
-  /* 
-    Validates the <TextInput> field to be only digits
-    Quite secure, as it will also check when trying to paste non-numeric inputs.
-
-    @Chrimle
-  */
-  const makeValidPatientID = (e) => {
+  
+  /**
+   * Validates the <TextInput> field to be only digits within certain length.
+   * Quite secure, as it will also check when trying to paste non-numeric inputs.
+   * @param  {String} id
+   * @author Christopher Molin
+   */
+  const makeValidPatientID = (id) => {
     setShowError("");
     const re = /^[0-9\b]+$/;
-      if (e.target.value === "" || re.test(e.target.value)) {
+      if (id.target.value === "" || re.test(id.target.value)) {
         setPatientID(() => {
-          return [e.target.value]
+          return [id.target.value]
         })
       }
   };
 
-
-  /* 
-    This method uses the global patientID to check if the provided patient exist.
-    patientID is checked to be the correct length and it is assumed REGEX ensures it is only digits.
-    Depending on if the patient exists, an error message will show resp. the redirecting-method will be called.
-
-    @Chrimle
-  */
+ 
+  /**
+   * Check if the provided patient exist and if the ID is of correct length.
+   * Ensures the doctor has permission to access the patient's EHR.
+   * Redirects if permitted, shown an error message if not.
+   * @author Christopher Molin
+   */
   const searchPatient = async () => {
     //alert("[DEBUG] Attempting to search for patient: "+patientID);
     if(patientID.toString().length === expectedPatientIDLength &&
       await EHRService.checkPatientExist(patientID)){
-        // This will occur only if the specified user exists
-        /*
-          PLACE CODE HERE
-          This is where a check for permission COULD be made. 
-        */
+        
         let connection = await chainConnection;
 
         let patID = "".concat(patientID);
@@ -68,8 +64,6 @@ export function PatientSearchScreen() {
         else{
           setShowError("Error: You lack permission to access "+patientID+"!");
         }
-
-        
       }
     else{
       setShowError("Error: "+patientID+" is not a valid patient ID!");
@@ -98,7 +92,7 @@ export function PatientSearchScreen() {
           </View>
         </View>
       </View> 
-      <Footer />
+      <Footer/>
     </View>
   );
 };


### PR DESCRIPTION
This PR brings:

- Handles non-existing EHRs, and shows placeholders when fields are empty.
- When doctors upload a new EHR, if the patient does not already have an EHR, it is now handled by skipping the download-procedure.
- Whether or not a doctor has permission to read a patient's EHR is checked on the PatientSearchScreen.

![image](https://user-images.githubusercontent.com/28791817/166503888-5874de72-50df-4121-b783-fb18301897d2.png)
