### PR TITLE
EHRService-refactoring

### DIFF
--- a/client/src/Helpers/ehrService.js
+++ b/client/src/Helpers/ehrService.js
@@ -51,7 +51,7 @@ export default class EHRService {
 
     this.setPrivateKey(privKey);
 
-    let pubKey = await FirebaseService.getPublicKey(); // ersätt med FirebaseService.getPublicKey
+    let pubKey = await FirebaseService.getPublicKey();
 
     this.setPublicKey(pubKey);
 

--- a/client/src/Helpers/ehrService.js
+++ b/client/src/Helpers/ehrService.js
@@ -245,7 +245,7 @@ export default class EHRService {
       // Put JSON files into list and upload
       finalFiles.push(ehrFile, prescriptionsFile, diagnosesFile);
       */
-      finalFiles.push( await this.createEHRFiles(objectEHR, prescriptions, diagnoses,index, patientID));
+      finalFiles = finalFiles.concat( await this.createEHRFiles(objectEHR, prescriptions, diagnoses,index, patientID));
 
       try{
         

--- a/client/src/Helpers/ehrService.js
+++ b/client/src/Helpers/ehrService.js
@@ -358,6 +358,8 @@ export default class EHRService {
       try{
         
         let newCID = await fs.uploadFiles(finalFiles);
+        
+        console.log(newCID);
 
         await connection.updateEHR(patientID, newCID);
         
@@ -445,10 +447,6 @@ export default class EHRService {
         decryptedEHRs: decryptedEHRs
     }
   }
-
-
-
-
 
 
   /**

--- a/client/src/Helpers/firebaseService.js
+++ b/client/src/Helpers/firebaseService.js
@@ -1,4 +1,5 @@
 import { database, ref, get, child } from "../../firebaseSetup";
+import { getAuth } from "@firebase/auth";
 
 export default class FirebaseService{
 
@@ -22,4 +23,120 @@ export default class FirebaseService{
             });
         return result;
     }
+
+    /**
+     * Fetches the public key for the currently logged in user.
+     * @returns {Promise<String>} returns the public key for the current user.
+     * @author David Zamanian
+     */
+    static async getPublicKey() {
+        let publicKey;
+        const auth = getAuth();
+        let dbRef = ref(database);
+        await get(child(dbRef, "mapUser/" + auth.currentUser.uid + "/publicKey/"))
+            .then((snapshot) => {
+                if (snapshot.exists()) {
+                    publicKey = snapshot.val();
+                } else {
+                    throw "No data available";
+                }
+            })
+            .catch((error) => {
+                throw error;
+            });
+        return publicKey;
+    }
+
+    /**
+   * Fetches the encrypted private key (and IV) of the current user from Firebase.
+   * @returns returns the encrypted private key + IV of the currently logged in user
+   * @author David Zamanian
+   */
+
+    static async getEncPrivateKeyAndIV() {
+        let encryptedPrivateKey;
+        const auth = getAuth();
+        let dbRef = ref(database);
+        await get(
+            child(dbRef, "mapUser/" + auth.currentUser.uid + "/IvAndPrivateKey/")
+        )
+            .then((snapshot) => {
+                if (snapshot.exists()) {
+                    encryptedPrivateKey = snapshot.val();
+                } else {
+                    throw "No data available";
+                }
+            })
+            .catch((error) => {
+                throw error;
+            });
+        return encryptedPrivateKey;
+    }
+
+
+    /**
+   * Fetches the current doctor's encrypted record key for the provided patient.
+   * @param {String} patientID The SSN/patientID of the patient
+   * @returns {*} The record key of the specified patient (if permission is granted)
+   * @author David Zamanian
+   */
+
+    static async getDoctorRecordKey(patientID) {
+        let encDoctorRecordKey;
+        const auth = getAuth();
+        let dbRef = ref(database);
+        await get(
+            child(
+                dbRef,
+                "DoctorToRecordKey/" + auth.currentUser.uid + "/recordKeys/" + patientID + "/recordKey/"
+            )
+        )
+            .then((snapshot) => {
+                if (snapshot.exists()) {
+                    encDoctorRecordKey = snapshot.val();
+                } else {
+                    //Maybe do something else here
+                    throw "Doctor does not have permission to view this patient's records";
+                }
+            })
+            .catch((error) => {
+                throw error;
+            });
+        return encDoctorRecordKey;
+    }
+
+    /**
+  * Fetches the current patient's record key.
+  * @returns The encrypted record key of the currently logged in patient
+  * @author David Zamanian
+  */
+
+    static async getPatientRecordKey() {
+        let encPatientRecordKey;
+        const auth = getAuth();
+        let dbRef = ref(database);
+        await get(
+            child(
+                dbRef,
+                "PatientToRecordKey/" + auth.currentUser.uid + "/recordKey"
+            )
+        )
+            .then((snapshot) => {
+                if (snapshot.exists()) {
+                    encPatientRecordKey = snapshot.val();
+                } else {
+                    //Maybe do something else here
+                    console.error("GetPatientRecordKey Error: " + auth.currentUser.uid);
+                    throw "Something went wrong";
+                }
+            })
+            .catch((error) => {
+                throw error;
+            });
+        return encPatientRecordKey;
+    }
+
+
+
+
 }

--- a/client/src/Helpers/firebaseService.js
+++ b/client/src/Helpers/firebaseService.js
@@ -1,0 +1,25 @@
+import { database, ref, get, child } from "../../firebaseSetup";
+
+export default class FirebaseService{
+
+
+    /**
+     * Checks to see if provided PatientID exists on Firebase
+     * @param  {String} patientID A patient ID to look up
+     * @returns {Promise<boolean>} Whether or not the patient exist
+     * @author Christopher Molin
+     */
+    static async checkPatientExist(patientID) {
+
+        let dbRef = ref(database);
+        let result = false;
+        await get(child(dbRef, "Patients/" + patientID))
+            .then((snapshot) => {
+                result = snapshot.exists();
+            })
+            .catch((error) => {
+                throw error;
+            });
+        return result;
+    }
+}

--- a/client/src/Helpers/firebaseService.js
+++ b/client/src/Helpers/firebaseService.js
@@ -136,7 +136,51 @@ export default class FirebaseService{
         return encPatientRecordKey;
     }
 
+    /**
+    * Fetches the name of the institution from Firebase.
+    * @param  {String} institution A valid id
+    * @returns {Promise<String>} The name of the institution
+    * @author Christopher Molin
+    */
+    static async getInstitutionName(institution) { // kommer ersättas av metod i chainconnection 
+        let dbRef = ref(database);
+        let institutionName = "";
+        await get(child(dbRef, "Institutions/" + institution))
+            .then((snapshot) => {
+                if (snapshot.exists()) {
+                    institutionName = snapshot.val().name;
+                } else {
+                    throw "No data available";
+                }
+            })
+            .catch((error) => {
+                throw error;
+            });
+        return institutionName;
+    }
 
+    /**
+   * Fetches the doctor's full name from Firebase.
+   * @param  {String} doctorID A valid SSN
+   * @returns {Promise<String>} Doctor's full name
+   * @author Christopher Molin
+   */
+    static async getDoctorFullName(doctorID) {
+        let dbRef = ref(database);
+        let fullName = "";
+        await get(child(dbRef, "Doctors/" + doctorID))
+            .then((snapshot) => {
+                if (snapshot.exists()) {
+                    fullName = snapshot.val().lastName + ", " + snapshot.val().firstName;
+                } else {
+                    throw "The requested doctor is not available";
+                }
+            })
+            .catch((error) => {
+                throw error;
+            });
+        return fullName;
+    }
 
 
 }

--- a/client/src/Helpers/firebaseService.js
+++ b/client/src/Helpers/firebaseService.js
@@ -49,10 +49,9 @@ export default class FirebaseService{
 
     /**
    * Fetches the encrypted private key (and IV) of the current user from Firebase.
-   * @returns returns the encrypted private key + IV of the currently logged in user
+   * @returns {Promise<*>} returns the encrypted private key + IV of the currently logged in user
    * @author David Zamanian
    */
-
     static async getEncPrivateKeyAndIV() {
         let encryptedPrivateKey;
         const auth = getAuth();
@@ -80,7 +79,6 @@ export default class FirebaseService{
    * @returns {*} The record key of the specified patient (if permission is granted)
    * @author David Zamanian
    */
-
     static async getDoctorRecordKey(patientID) {
         let encDoctorRecordKey;
         const auth = getAuth();
@@ -106,11 +104,10 @@ export default class FirebaseService{
     }
 
     /**
-  * Fetches the current patient's record key.
-  * @returns The encrypted record key of the currently logged in patient
-  * @author David Zamanian
-  */
-
+    * Fetches the current patient's record key.
+    * @returns The encrypted record key of the currently logged in patient
+    * @author David Zamanian
+    */
     static async getPatientRecordKey() {
         let encPatientRecordKey;
         const auth = getAuth();

--- a/client/src/screens/Overview/EHROverviewScreen.js
+++ b/client/src/screens/Overview/EHROverviewScreen.js
@@ -95,7 +95,7 @@ export function EHROverviewScreen(props) {
           const patientPermittedRegions = await EHRService.getPatientRegions((state.doctorRole ? props.route.params : userSSN ))
 */
 
-          let ehr = await EHRService.getEHR((state.doctorRole ? props.route.params : userSSN ), role);
+          let ehr = await EHRService.getEHR((state.doctorRole ? props.route.params : userSSN ), role, false);
 
           const patientPrescriptions = ehr.prescriptions
           const patientDiagnoses = ehr.diagnoses;

--- a/client/src/screens/Overview/EHROverviewScreen.js
+++ b/client/src/screens/Overview/EHROverviewScreen.js
@@ -734,7 +734,7 @@ export function EHROverviewScreen(props) {
         <View style={styles.rowContainer}>
           <View style={[styles.container, styles.doubleContainer]}>
             <Text style={styles.header}>Past record entries</Text>
-            {state.patientInfo.prescriptions.length > 0 ?
+            {state.patientInfo.journals.length > 0 ?
             <FlatList
               style={{ width: "100%" }}
               data={state.patientInfo.journals}

--- a/client/src/screens/StaffScreens/NewEntryScreen/NewEntryScreen.js
+++ b/client/src/screens/StaffScreens/NewEntryScreen/NewEntryScreen.js
@@ -12,6 +12,7 @@ import ThemeButton from "../../../components/themeButton";
 import EHRService from "../../../Helpers/ehrService";
 import { UserDataContext } from "../../../../contexts/UserDataContext";
 import { ChainConnectionContext } from "../../../../contexts/ChainConnectionContext";
+import FirebaseService from "../../../Helpers/firebaseService";
 
 
 export function NewEntryScreen(props) {
@@ -155,9 +156,9 @@ export function NewEntryScreen(props) {
     // Add diagnoses to diagnoses list
     diagnosesList.forEach(element => diagnoseList.push(element.diagnosis.toString()));
 
-    let medicalPersonnel = await EHRService.getDoctorFullName(userSSN);
+    let medicalPersonnel = await FirebaseService.getDoctorFullName(userSSN);
 
-    let healthcareInstitution = await EHRService.getInstitutionName(institution);
+    let healthcareInstitution = await FirebaseService.getInstitutionName(institution);
 
 
     console.log(medicalPersonnel+institution+healthcareInstitution);

--- a/client/src/screens/StaffScreens/PatientSearchScreen/PatientSearchScreen.js
+++ b/client/src/screens/StaffScreens/PatientSearchScreen/PatientSearchScreen.js
@@ -7,6 +7,7 @@ import styles from "./styles";
 import { useNavigation } from "@react-navigation/native";
 import EHRService from "../../../Helpers/ehrService";
 import { ChainConnectionContext } from "../../../../contexts/ChainConnectionContext";
+import FirebaseService from "../../../Helpers/firebaseService";
 
 export function PatientSearchScreen() {
 
@@ -50,7 +51,7 @@ export function PatientSearchScreen() {
   const searchPatient = async () => {
     //alert("[DEBUG] Attempting to search for patient: "+patientID);
     if(patientID.toString().length === expectedPatientIDLength &&
-      await EHRService.checkPatientExist(patientID)){
+      await FirebaseService.checkPatientExist(patientID)){
         
         let connection = await chainConnection;
 


### PR DESCRIPTION
Decomposed EHRService a bit. Moved Firebase-related methods to the more appropriately named `FirebaseService`-class. Also made the final adjustments to make the the upload-procedure simply call the download-procedure before uploading. This reduced the duplicated-code problem, but there's still room for improvement I think. One such thing is the ever re-appearing `chainConnection` as well as `Web3Storage`-token. These should belong to the class `EHRService` and be set at init, but this requires a babel-dependency for static init blocks.